### PR TITLE
[FEAT] 게시물 등록 구현 2

### DIFF
--- a/src/main/java/com/spoony/spoony_server/domain/post/repository/FeedRepository.java
+++ b/src/main/java/com/spoony/spoony_server/domain/post/repository/FeedRepository.java
@@ -1,0 +1,7 @@
+package com.spoony.spoony_server.domain.post.repository;
+
+import com.spoony.spoony_server.domain.post.entity.FeedEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FeedRepository extends JpaRepository<FeedEntity, Long> {
+}

--- a/src/main/java/com/spoony/spoony_server/domain/post/repository/FollowRepository.java
+++ b/src/main/java/com/spoony/spoony_server/domain/post/repository/FollowRepository.java
@@ -1,0 +1,11 @@
+package com.spoony.spoony_server.domain.post.repository;
+
+import com.spoony.spoony_server.domain.user.entity.FollowEntity;
+import com.spoony.spoony_server.domain.user.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FollowRepository extends JpaRepository<FollowEntity, Long> {
+    List<FollowEntity> findByFollowing(UserEntity following);
+}

--- a/src/main/java/com/spoony/spoony_server/domain/post/repository/ZzimPostRepository.java
+++ b/src/main/java/com/spoony/spoony_server/domain/post/repository/ZzimPostRepository.java
@@ -1,0 +1,7 @@
+package com.spoony.spoony_server.domain.post.repository;
+
+import com.spoony.spoony_server.domain.post.entity.ZzimPostEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ZzimPostRepository extends JpaRepository<ZzimPostEntity, Long> {
+}

--- a/src/main/java/com/spoony/spoony_server/domain/user/entity/FollowEntity.java
+++ b/src/main/java/com/spoony/spoony_server/domain/user/entity/FollowEntity.java
@@ -2,9 +2,11 @@ package com.spoony.spoony_server.domain.user.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @Table(name = "follow")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FollowEntity {


### PR DESCRIPTION
### 📝 Work Description
- 게시물 등록 구현 두 번째 단계를 완료하였습니다.
- 게시물이 등록되면 작성자의 지도 리스트에 해당 게시물이 추가되도록 구현하였습니다.
- 게시물이 등록되면 작성자를 팔로우하는 사용자들의 피드 리스트에 해당 게시물이 추가되도록 구현하였습니다.

### ⚙️ Issue
[//]: # (연관된 이슈 번호)
- #15 

### 🔨 Changes
- 게시물 등록 관련 로직이 추가되었습니다.

### 🔍 PR Point
- 게시물 등록 시, 연관된 모든 작업이 일괄적으로 처리되는지 확인!