### PR TITLE
[FEAT] S3 설정, 개인 정보 yml로 이동

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -32,6 +32,16 @@ jobs:
           echo "${{ secrets.CD_APPLICATION }}" > ./src/main/resources/application.yml
           cat ./src/main/resources/application.yml
 
+      - name: Generate application-aws.yml
+        run: |
+          echo "${{ secrets.CD_APPLICATION_AWS }}" > ./src/main/resources/application-aws.yml
+          cat ./src/main/resources/application-aws.yml
+
+      - name: Generate application-naver.yml
+        run: |
+          echo "${{ secrets.CD_APPLICATION_NAVER }}" > ./src/main/resources/application-naver.yml
+          cat ./src/main/resources/application-naver.yml
+
       - name: Build Project
         run: ./gradlew clean build -x test
 

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ out/
 .vscode/
 
 application.yml
+application-aws.yml
+application-naver.yml

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/spoony/spoony_server/common/message/S3ErrorMessage.java
+++ b/src/main/java/com/spoony/spoony_server/common/message/S3ErrorMessage.java
@@ -1,0 +1,24 @@
+package com.spoony.spoony_server.common.message;
+
+import org.springframework.http.HttpStatus;
+
+public enum S3ErrorMessage implements DefaultErrorMessage {
+    FILE_CHANGE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "MultipartFile을 File로 변환하는 과정에서 문제가 발생했습니다."),
+    USER_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "스푼 정보가 없는 사용자입니다.");
+
+    private HttpStatus httpStatus;
+    private String message;
+
+    S3ErrorMessage(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/spoony/spoony_server/domain/place/controller/PlaceController.java
@@ -10,6 +10,7 @@ import com.spoony.spoony_server.domain.place.dto.request.PlaceCheckResponseDTO;
 import com.spoony.spoony_server.domain.place.dto.response.PlaceListResponseDTO;
 import com.spoony.spoony_server.domain.place.dto.response.PlaceResponseDTO;
 import com.spoony.spoony_server.domain.place.service.PlaceService;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -26,6 +27,12 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/place")
 public class PlaceController {
+
+    @Value("${naver.clientId}")
+    private String clientId;
+    @Value("${naver.clientSecret}")
+    private String clientSecret;
+
     public final PlaceService placeService;
 
     public PlaceController(PlaceService placeService) {
@@ -36,10 +43,6 @@ public class PlaceController {
     public ResponseEntity<ResponseDTO<PlaceListResponseDTO>> getPlaceList(
             @RequestParam(name = "query") String query,
             @RequestParam(name = "display", required = false, defaultValue = "5") int display) {
-
-        // 네이버 지역 검색 API
-        String clientId = "RftWm05kMhRNzohzXoIO";
-        String clientSecret = "6GAKpX5obG";
 
         URI uri = UriComponentsBuilder
                 .fromUriString("https://openapi.naver.com")

--- a/src/main/java/com/spoony/spoony_server/infra/config/S3Config.java
+++ b/src/main/java/com/spoony/spoony_server/infra/config/S3Config.java
@@ -1,0 +1,28 @@
+package com.spoony.spoony_server.infra.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/infra/service/AwsFileService.java
+++ b/src/main/java/com/spoony/spoony_server/infra/service/AwsFileService.java
@@ -1,0 +1,84 @@
+package com.spoony.spoony_server.infra.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.spoony.spoony_server.common.exception.BusinessException;
+import com.spoony.spoony_server.common.message.S3ErrorMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class AwsFileService {
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private String PROFILE_IMG_DIR = "profile/";
+    private String POST_IMG_DIR = "post/";
+
+    public String savePhoto(MultipartFile multipartFile, Long memberId) throws IOException {
+        File uploadFile = convert(multipartFile)
+                .orElseThrow(() -> new BusinessException(S3ErrorMessage.FILE_CHANGE_FAIL));
+        return upload(uploadFile, POST_IMG_DIR, memberId);
+    }
+
+    public String saveProfileImg(MultipartFile multipartFile, Long memberId) throws IOException {
+        File uploadFile = convert(multipartFile)
+                .orElseThrow(() -> new BusinessException(S3ErrorMessage.FILE_CHANGE_FAIL));
+        return upload(uploadFile, PROFILE_IMG_DIR, memberId);
+    }
+
+    private String upload(File uploadFile, String dirName, Long memberId) {
+        String fileName = dirName + memberId + "/" + UUID.randomUUID() + uploadFile.getName();   // S3에 저장된 파일 이름
+        String uploadImageUrl = putS3(uploadFile, fileName);
+        removeNewFile(uploadFile);
+        return uploadImageUrl;
+    }
+
+    private String putS3(File uploadFile, String fileName) {
+        amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, uploadFile).withCannedAcl(
+                CannedAccessControlList.PublicRead));
+        return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+
+    private void removeNewFile(File targetFile) {
+        if (targetFile.delete()) {
+            log.info("File delete success");
+            return;
+        }
+        log.info("File delete fail");
+    }
+
+    private Optional<File> convert(MultipartFile file) throws IOException {
+        File convertFile = new File(System.getProperty("user.home") + "/" + file.getOriginalFilename());
+        if (convertFile.createNewFile()) {
+            try (FileOutputStream fos = new FileOutputStream(convertFile)) {
+                fos.write(file.getBytes());
+            }
+            return Optional.of(convertFile);
+        }
+        return Optional.empty();
+    }
+
+    public void createDir(String bucketName, String folderName) {
+        amazonS3Client.putObject(bucketName, folderName + "/", new ByteArrayInputStream(new byte[0]), new ObjectMetadata());
+    }
+}


### PR DESCRIPTION
### 📝 Work Description
- S3 사용을 위한 설정 코드를 구현하였습니다.
- Naver, AWS 관련 개인 정보는 `.yml` 파일로 이동되었습니다.

### ⚙️ Issue
[//]: # (연관된 이슈 번호)
- #19 

### 🔨 Changes
- S3 사용 준비 완료되었습니다.
- Naver, AWS 관련 정보가 코드에 노출되지 않도록 하였습니다.