### PR TITLE
[FEAT] 피드 조회 API 데이터 누락 수정, 구조 개선

### DIFF
--- a/src/main/java/com/spoony/spoony_server/domain/post/controller/FeedController.java
+++ b/src/main/java/com/spoony/spoony_server/domain/post/controller/FeedController.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-
 @RestController
 @RequestMapping("/api/feed")
 @RequiredArgsConstructor
@@ -16,23 +15,13 @@ public class FeedController {
 
     private final FeedService feedService;
 
-    @GetMapping("/{userId}")
-    public ResponseEntity<ResponseDTO<FeedListResponseDTO>> getAllFeeds(@PathVariable Long userId,
-                                                                        @RequestParam(name = "query") String locationQuery,
-                                                                        @RequestParam(name = "sortBy") String sortBy) {
-
-        FeedListResponseDTO feedListResponse = feedService.getFeedList(userId, locationQuery, sortBy);
-
-        return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(feedListResponse));
-    }
-
     @GetMapping("/{userId}/{categoryId}")
-    public ResponseEntity<ResponseDTO<FeedListResponseDTO>> getFilteredFeedsByCategory(@PathVariable Long userId, @PathVariable Long categoryId,
-                                                                                       @RequestParam(name = "query") String locationQuery,
-                                                                                       @RequestParam(name = "sortBy") String sortBy) {
+    public ResponseEntity<ResponseDTO<FeedListResponseDTO>> getPost(@PathVariable Long userId,
+                                                                    @PathVariable Long categoryId,
+                                                                    @RequestParam(name = "query") String locationQuery,
+                                                                    @RequestParam(name = "sortBy") String sortBy) {
+        FeedListResponseDTO feedListResponse = feedService.getFeedListByUserId(userId, categoryId, locationQuery, sortBy);
 
-        FeedListResponseDTO feedListResponse = feedService.getFeedListByCategory(userId, categoryId, locationQuery, sortBy);
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(feedListResponse));
-        
     }
 }

--- a/src/main/java/com/spoony/spoony_server/domain/post/dto/response/FeedResponseDTO.java
+++ b/src/main/java/com/spoony/spoony_server/domain/post/dto/response/FeedResponseDTO.java
@@ -5,10 +5,11 @@ import java.time.LocalDateTime;
 public record FeedResponseDTO(
         Long userId,
         String userName,
-        LocalDateTime createdAt,
-        RegionDTO userRegion,
+        String userRegion,
+        Long postId,
         String title,
         CategoryColorResponseDTO categoryColorResponseDTO,
-        Long zzimCount
+        Long zzimCount,
+        LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/com/spoony/spoony_server/domain/post/service/FeedService.java
+++ b/src/main/java/com/spoony/spoony_server/domain/post/service/FeedService.java
@@ -6,12 +6,13 @@ import com.spoony.spoony_server.common.message.UserErrorMessage;
 import com.spoony.spoony_server.domain.post.dto.response.CategoryColorResponseDTO;
 import com.spoony.spoony_server.domain.post.dto.response.FeedListResponseDTO;
 import com.spoony.spoony_server.domain.post.dto.response.FeedResponseDTO;
-import com.spoony.spoony_server.domain.post.dto.response.RegionDTO;
 import com.spoony.spoony_server.domain.post.entity.CategoryEntity;
 import com.spoony.spoony_server.domain.post.entity.FeedEntity;
 import com.spoony.spoony_server.domain.post.entity.PostCategoryEntity;
 import com.spoony.spoony_server.domain.post.entity.PostEntity;
-import com.spoony.spoony_server.domain.post.repository.*;
+import com.spoony.spoony_server.domain.post.repository.FeedRepository;
+import com.spoony.spoony_server.domain.post.repository.PostCategoryRepository;
+import com.spoony.spoony_server.domain.post.repository.ZzimPostRepository;
 import com.spoony.spoony_server.domain.user.entity.UserEntity;
 import com.spoony.spoony_server.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,44 +21,51 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.stream.Collectors;
 
-//
-//@
 @Service
 @RequiredArgsConstructor
 public class FeedService {
     private final UserRepository userRepository;
     private final FeedRepository feedRepository;
-    private final PostRepository postRepository;
-    private final CategoryRepository categoryRepository;
     private final PostCategoryRepository postCategoryRepository;
     private final ZzimPostRepository zzimPostRepository;
 
-
-    public FeedListResponseDTO getFeedList(Long userId, String location_query, String sortBy) {
+    public FeedListResponseDTO getFeedListByUserId(Long userId, Long categoryId, String location_query, String sortBy) {
 
         UserEntity userEntity = userRepository.findById(userId).orElseThrow(() -> new BusinessException(UserErrorMessage.USER_NOT_FOUND));
         List<FeedEntity> feedEntityList = feedRepository.findByUser(userEntity);
 
         List<FeedResponseDTO> feedResponseList = feedEntityList.stream()
                 .filter(feedEntity -> feedEntity.getPost().getPlace().getPlaceAddress().contains(location_query))
+                .filter(feedEntity -> {
+                    if (categoryId == 1) {
+                        return true;
+                    }
+                    PostEntity postEntity = feedEntity.getPost();
+                    PostCategoryEntity postCategoryEntity = postCategoryRepository.findByPost(postEntity).orElseThrow(() -> new BusinessException(PostErrorMessage.POST_NOT_FOUND));
+                    return postCategoryEntity.getCategory().getCategoryId().equals(categoryId);
+                })
                 .map(feedEntity -> {
                     PostEntity postEntity = feedEntity.getPost();
                     UserEntity authorUserEntity = postEntity.getUser();
-                    PostCategoryEntity postCategoryEntity = postCategoryRepository.findByPost(postEntity).orElseThrow(() -> new BusinessException(PostErrorMessage.POST_NOT_FOUND));
-                    CategoryEntity eachCategoryEntity = postCategoryEntity.getCategory();
-
+                    PostCategoryEntity postCategoryEntity = postCategoryRepository.findByPost(postEntity)
+                            .orElseThrow(() -> new BusinessException(PostErrorMessage.POST_NOT_FOUND));
+                    CategoryEntity categoryEntity = postCategoryEntity.getCategory();
 
                     return new FeedResponseDTO(
                             authorUserEntity.getUserId(),
                             authorUserEntity.getUserName(),
-                            postEntity.getCreatedAt(), new RegionDTO(authorUserEntity.getRegion().getRegionId(), authorUserEntity.getRegion().getRegionName()),
+                            authorUserEntity.getRegion().getRegionName(),
+                            postEntity.getPostId(),
                             postEntity.getTitle(),
-
                             new CategoryColorResponseDTO(
-                                    postCategoryRepository.findByPost(postEntity).orElseThrow(() -> new BusinessException(PostErrorMessage.POST_NOT_FOUND)).getCategory().getCategoryName(),
-                                    postCategoryRepository.findByPost(postEntity).orElseThrow(() -> new BusinessException(PostErrorMessage.POST_NOT_FOUND)).getCategory().getIconUrlColor(),
-                                    postCategoryRepository.findByPost(postEntity).orElseThrow(() -> new BusinessException(PostErrorMessage.POST_NOT_FOUND)).getCategory().getTextColor(),
-                                    postCategoryRepository.findByPost(postEntity).orElseThrow(() -> new BusinessException(PostErrorMessage.POST_NOT_FOUND)).getCategory().getBackgroundColor()), zzimPostRepository.countByPost(postEntity));
+                                    categoryEntity.getCategoryName(),
+                                    categoryEntity.getIconUrlColor(),
+                                    categoryEntity.getTextColor(),
+                                    categoryEntity.getBackgroundColor()
+                            ),
+                            zzimPostRepository.countByPost(postEntity),
+                            postEntity.getCreatedAt()
+                    );
                 })
                 .collect(Collectors.toList());
 
@@ -69,46 +77,4 @@ public class FeedService {
 
         return new FeedListResponseDTO(feedResponseList);
     }
-
-
-    public FeedListResponseDTO getFeedListByCategory(Long userId, Long categoryId, String location_query, String sortBy) {
-        UserEntity userEntity = userRepository.findById(userId).orElseThrow(() -> new BusinessException(UserErrorMessage.USER_NOT_FOUND));
-        List<FeedEntity> feedEntityList = feedRepository.findByUser(userEntity);
-
-        List<FeedResponseDTO> feedResponseList = feedEntityList.stream()
-                .filter(feedEntity -> feedEntity.getPost().getPlace().getPlaceAddress().contains(location_query))
-                .filter(feedEntity -> {
-                    PostEntity postEntity = feedEntity.getPost();
-                    PostCategoryEntity postCategoryEntity = postCategoryRepository.findByPost(postEntity).orElseThrow(() -> new BusinessException(PostErrorMessage.POST_NOT_FOUND));
-                    return postCategoryEntity.getCategory().getCategoryId().equals(categoryId);
-                })
-                .map(feedEntity -> {
-                    PostEntity postEntity = feedEntity.getPost();
-                    UserEntity authorUserEntity = postEntity.getUser();
-                    PostCategoryEntity postCategoryEntity = postCategoryRepository.findByPost(postEntity).orElseThrow(() -> new BusinessException(PostErrorMessage.POST_NOT_FOUND));
-                    CategoryEntity eachCategoryEntity = postCategoryEntity.getCategory();
-
-
-                    return new FeedResponseDTO(
-                            authorUserEntity.getUserId(),
-                            authorUserEntity.getUserName(),
-                            postEntity.getCreatedAt(), new RegionDTO(authorUserEntity.getRegion().getRegionId(), authorUserEntity.getRegion().getRegionName()),
-                            postEntity.getTitle(),
-                            new CategoryColorResponseDTO(
-                                    postCategoryRepository.findByPost(postEntity).orElseThrow(() -> new BusinessException(PostErrorMessage.POST_NOT_FOUND)).getCategory().getCategoryName(),
-                                    postCategoryRepository.findByPost(postEntity).orElseThrow(() -> new BusinessException(PostErrorMessage.POST_NOT_FOUND)).getCategory().getIconUrlColor(),
-                                    postCategoryRepository.findByPost(postEntity).orElseThrow(() -> new BusinessException(PostErrorMessage.POST_NOT_FOUND)).getCategory().getTextColor(),
-                                    postCategoryRepository.findByPost(postEntity).orElseThrow(() -> new BusinessException(PostErrorMessage.POST_NOT_FOUND)).getCategory().getBackgroundColor()),
-                            zzimPostRepository.countByPost(postEntity)
-                    );
-                }).collect(Collectors.toList());
-        if (sortBy.equals("popularity")) {
-            feedResponseList.sort((dto1, dto2) -> Long.compare(dto2.zzimCount(), dto1.zzimCount()));
-        } else if (sortBy.equals("latest")) {
-            feedResponseList.sort((dto1, dto2) -> dto2.createdAt().compareTo(dto1.createdAt()));
-        }
-
-        return new FeedListResponseDTO(feedResponseList);
-    }
-
 }


### PR DESCRIPTION
### 📝 Work Description
- 피드 조회 시 게시물 ID가 누락된 문제를 해결하였습니다.
- 두 개의 API로 나눠진 피드 조회 로직을 하나로 통합하였습니다.
- 내부 코드 구조를 개선하여 복잡함을 완화했습니다.

### ⚙️ Issue
[//]: # (연관된 이슈 번호)
- closed #64 

### 🔨 Changes
- Feed 관련 Controller, Service, DTO 수정

### 🔍 PR Point
- `map` 내부 처리가 어떻게 변했는지 확인해보면 좋을 것 같습니다.