### PR TITLE
[FIX] 지도 리스트 조회 API 이미지 누락 수정

### DIFF
--- a/src/main/java/com/spoony/spoony_server/domain/post/repository/PhotoRepository.java
+++ b/src/main/java/com/spoony/spoony_server/domain/post/repository/PhotoRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 
 public interface PhotoRepository extends JpaRepository<PhotoEntity, Long> {
     Optional<List<PhotoEntity>> findByPost(PostEntity post);
+
+    Optional<PhotoEntity> findFirstByPost(PostEntity postEntity);
 }

--- a/src/main/java/com/spoony/spoony_server/domain/zzim/dto/response/ZzimCardResponseDTO.java
+++ b/src/main/java/com/spoony/spoony_server/domain/zzim/dto/response/ZzimCardResponseDTO.java
@@ -6,6 +6,7 @@ public record ZzimCardResponseDTO(Long placeId,
                                   String placeName,
                                   String placeAddress,
                                   String postTitle,
+                                  String photoUrl,
                                   Double latitude,
                                   Double longitude,
                                   CategoryColorResponseDTO categoryColorResponse) {

--- a/src/main/java/com/spoony/spoony_server/domain/zzim/service/ZzimPostService.java
+++ b/src/main/java/com/spoony/spoony_server/domain/zzim/service/ZzimPostService.java
@@ -88,6 +88,9 @@ public class ZzimPostService {
                     PostEntity postEntity = zzimPostEntity.getPost();
                     PlaceEntity placeEntity = postEntity.getPlace();
 
+                    PhotoEntity photoEntity = photoRepository.findFirstByPost(postEntity)
+                            .orElseThrow(() -> new BusinessException(PostErrorMessage.PHOTO_NOT_FOUND));
+
                     CategoryColorResponseDTO categoryColorResponse = postCategoryRepository.findByPost(postEntity)
                             .map(PostCategoryEntity::getCategory)
                             .map(categoryEntity -> new CategoryColorResponseDTO(
@@ -103,6 +106,7 @@ public class ZzimPostService {
                             placeEntity.getPlaceName(),
                             placeEntity.getPlaceAddress(),
                             postEntity.getTitle(),
+                            photoEntity.getPhotoUrl(),
                             placeEntity.getLatitude(),
                             placeEntity.getLongitude(),
                             categoryColorResponse
@@ -214,6 +218,9 @@ public class ZzimPostService {
                     PostEntity postEntity = zzimPostEntity.getPost();
                     PlaceEntity placeEntity = postEntity.getPlace();
 
+                    PhotoEntity photoEntity = photoRepository.findFirstByPost(postEntity)
+                            .orElseThrow(() -> new BusinessException(PostErrorMessage.PHOTO_NOT_FOUND));
+
                     CategoryColorResponseDTO categoryColorResponse = postCategoryRepository.findByPost(postEntity)
                             .map(PostCategoryEntity::getCategory)
                             .map(categoryEntity -> new CategoryColorResponseDTO(
@@ -229,6 +236,7 @@ public class ZzimPostService {
                             placeEntity.getPlaceName(),
                             placeEntity.getPlaceAddress(),
                             postEntity.getTitle(),
+                            photoEntity.getPhotoUrl(),
                             placeEntity.getLatitude(),
                             placeEntity.getLongitude(),
                             categoryColorResponse
@@ -271,6 +279,9 @@ public class ZzimPostService {
                     PostEntity postEntity = zzimPostEntity.getPost();
                     PlaceEntity placeEntity = postEntity.getPlace();
 
+                    PhotoEntity photoEntity = photoRepository.findFirstByPost(postEntity)
+                            .orElseThrow(() -> new BusinessException(PostErrorMessage.PHOTO_NOT_FOUND));
+
                     CategoryColorResponseDTO categoryColorResponse = postCategoryRepository.findByPost(postEntity)
                             .map(PostCategoryEntity::getCategory)
                             .map(categoryEntity -> new CategoryColorResponseDTO(
@@ -286,6 +297,7 @@ public class ZzimPostService {
                             placeEntity.getPlaceName(),
                             placeEntity.getPlaceAddress(),
                             postEntity.getTitle(),
+                            photoEntity.getPhotoUrl(),
                             placeEntity.getLatitude(),
                             placeEntity.getLongitude(),
                             categoryColorResponse


### PR DESCRIPTION
### 📝 Work Description
- 지도 리스트 조회 시 첫 번째 게시물의 첫 번째 이미지가 포함되도록 수정되었습니다.

### ⚙️ Issue
[//]: # (연관된 이슈 번호)
- closed #70 