### PR TITLE
[FIX] 색깔 카테고리 반환 시 카테고리 ID 추가

### DIFF
--- a/src/main/java/com/spoony/spoony_server/domain/post/dto/response/CategoryColorResponseDTO.java
+++ b/src/main/java/com/spoony/spoony_server/domain/post/dto/response/CategoryColorResponseDTO.java
@@ -1,6 +1,7 @@
 package com.spoony.spoony_server.domain.post.dto.response;
 
-public record CategoryColorResponseDTO(String categoryName,
+public record CategoryColorResponseDTO(Long categoryId,
+                                       String categoryName,
                                        String iconUrl,
                                        String iconTextColor,
                                        String iconBackgroundColor) {

--- a/src/main/java/com/spoony/spoony_server/domain/post/service/FeedService.java
+++ b/src/main/java/com/spoony/spoony_server/domain/post/service/FeedService.java
@@ -59,6 +59,7 @@ public class FeedService {
                             postEntity.getPostId(),
                             postEntity.getTitle(),
                             new CategoryColorResponseDTO(
+                                    categoryEntity.getCategoryId(),
                                     categoryEntity.getCategoryName(),
                                     categoryEntity.getIconUrlColor(),
                                     categoryEntity.getTextColor(),

--- a/src/main/java/com/spoony/spoony_server/domain/post/service/PostService.java
+++ b/src/main/java/com/spoony/spoony_server/domain/post/service/PostService.java
@@ -79,12 +79,6 @@ public class PostService {
         List<PhotoEntity> photoEntityList = photoRepository.findByPost(postEntity)
                 .orElseThrow(() -> new BusinessException(PostErrorMessage.PHOTO_NOT_FOUND));
 
-        String iconUrlColor = categoryEntity.getIconUrlColor();
-        String backgroundColor = categoryEntity.getBackgroundColor();
-        String textColor = categoryEntity.getTextColor();
-
-        String category = categoryEntity.getCategoryName();
-
         List<MenuEntity> menuEntityList = menuRepository.findByPost(postEntity)
                 .orElseThrow(() -> new BusinessException(PostErrorMessage.MENU_NOT_FOUND));
 
@@ -110,7 +104,12 @@ public class PostService {
                 zzimCount,
                 isZzim,
                 isScoop,
-                new CategoryColorResponseDTO(category, iconUrlColor, textColor, backgroundColor)
+                new CategoryColorResponseDTO(
+                        categoryEntity.getCategoryId(),
+                        categoryEntity.getCategoryName(),
+                        categoryEntity.getIconUrlColor(),
+                        categoryEntity.getTextColor(),
+                        categoryEntity.getBackgroundColor())
         );
     }
 

--- a/src/main/java/com/spoony/spoony_server/domain/zzim/service/ZzimPostService.java
+++ b/src/main/java/com/spoony/spoony_server/domain/zzim/service/ZzimPostService.java
@@ -94,6 +94,7 @@ public class ZzimPostService {
                     CategoryColorResponseDTO categoryColorResponse = postCategoryRepository.findByPost(postEntity)
                             .map(PostCategoryEntity::getCategory)
                             .map(categoryEntity -> new CategoryColorResponseDTO(
+                                    categoryEntity.getCategoryId(),
                                     categoryEntity.getCategoryName(),
                                     categoryEntity.getIconUrlColor(),
                                     categoryEntity.getTextColor(),
@@ -136,6 +137,7 @@ public class ZzimPostService {
                     CategoryColorResponseDTO categoryColorResponse = postCategoryRepository.findByPost(postEntity)
                             .map(PostCategoryEntity::getCategory)
                             .map(categoryEntity -> new CategoryColorResponseDTO(
+                                    categoryEntity.getCategoryId(),
                                     categoryEntity.getCategoryName(),
                                     categoryEntity.getIconUrlColor(),
                                     categoryEntity.getTextColor(),
@@ -224,6 +226,7 @@ public class ZzimPostService {
                     CategoryColorResponseDTO categoryColorResponse = postCategoryRepository.findByPost(postEntity)
                             .map(PostCategoryEntity::getCategory)
                             .map(categoryEntity -> new CategoryColorResponseDTO(
+                                    categoryEntity.getCategoryId(),
                                     categoryEntity.getCategoryName(),
                                     categoryEntity.getIconUrlColor(),
                                     categoryEntity.getTextColor(),
@@ -285,6 +288,7 @@ public class ZzimPostService {
                     CategoryColorResponseDTO categoryColorResponse = postCategoryRepository.findByPost(postEntity)
                             .map(PostCategoryEntity::getCategory)
                             .map(categoryEntity -> new CategoryColorResponseDTO(
+                                    categoryEntity.getCategoryId(),
                                     categoryEntity.getCategoryName(),
                                     categoryEntity.getIconUrlColor(),
                                     categoryEntity.getTextColor(),


### PR DESCRIPTION
### 📝 Work Description
- 클라이언트 측에서 흑백 카테고리와 컬러 카테고리 소비 시 같은 엔티티 객체를 사용하고 싶다고 요청하였습니다.
- 그에 따라, 컬러 카테고리 반환 시에도 Id를 반환하여(실제 사용되진 않지만), `categoryId`를 엔티티의 키로 사용할 수 있도록 하였습니다.

### ⚙️ Issue
[//]: # (연관된 이슈 번호)
- closed #72 

### 🔨 Changes
- 컬러 카테고리 조회 시 항상 `categoryId` 정보를 포함하도록 하였습니다. (DTO 수정)

### 🔍 PR Point
- 추후 개발을 진행하면서도, 엔티티 객체를 통일하려는 클라이언트 측 아키텍처를 이해하며 DTO를 설정하면 좋을 것 같습니다!