### PR TITLE
[FEAT] 장소 검색 결과 HTML 특수 문자 필터링

### DIFF
--- a/src/main/java/com/spoony/spoony_server/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/spoony/spoony_server/domain/place/controller/PlaceController.java
@@ -18,6 +18,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.HtmlUtils;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
@@ -73,7 +74,9 @@ public class PlaceController {
             List<PlaceResponseDTO> places = new ArrayList<>();
 
             placeList.get("items").forEach(item -> {
-                String title = item.get("title").asText().replaceAll("<[^>]*>", ""); // HTML 태그 제거
+                String title = HtmlUtils.htmlUnescape(
+                        item.get("title").asText().replaceAll("<[^>]*>", "") // HTML 태그 제거
+                );
                 String address = item.get("address").asText();
                 String roadAddress = item.get("roadAddress").asText();
                 Double mapx = item.get("mapx").asDouble();


### PR DESCRIPTION
### 📝 Work Description
- 네이버 장소 검색 API에서 반환하는 검색 결과에 HTML 특수 문자가 존재한다는 것을 알게 되었습니다. (웹 기준 반환 결과로 추정)
- 이에 따라 HTML 태그를 전부 제외한 결과를 반환하도록 수정하였고, 그 과정에서 `HtmlUtils.htmlUnescape`를 사용했습니다.

### ⚙️ Issue
[//]: # (연관된 이슈 번호)
- closed #75 

### 🔨 Changes
- `PlaceController`에서 장소를 검색하는 부분이 일부 수정되었습니다.

### 🔍 PR Point
- `Spring Web`에서 지원하는 `HtmlUtils`를 사용한 점을 살펴보면 좋을 것 같습니다!