### PR TITLE
[FIX] 동 지역 검색 기준을 주소에서 거리로 임시 변경

### DIFF
--- a/src/main/java/com/spoony/spoony_server/domain/zzim/service/ZzimPostService.java
+++ b/src/main/java/com/spoony/spoony_server/domain/zzim/service/ZzimPostService.java
@@ -184,10 +184,12 @@ public class ZzimPostService {
         LocationEntity locationEntity = locationRepository.findById(locationId)
                 .orElseThrow(() -> new BusinessException(PostErrorMessage.LOCATION_NOT_FOUND));
 
-        if (locationEntity.getLocationTypeEntity().getLocationTypeId() == 3) {
+        if (locationEntity.getLocationTypeEntity().getLocationTypeId() == 1) {
             return getZzimByAddress(userId, locationEntity.getLocationAddress());
+        } else if (locationEntity.getLocationTypeEntity().getLocationTypeId() == 2) {
+            return getZzimByAreaDong(userId, locationEntity.getLongitude(), locationEntity.getLatitude());
         } else {
-            return getZzimByArea(userId, locationEntity.getLongitude(), locationEntity.getLatitude());
+            return getZzimByAreaStation(userId, locationEntity.getLongitude(), locationEntity.getLatitude());
         }
     }
 
@@ -250,7 +252,7 @@ public class ZzimPostService {
         return new ZzimCardListResponseDTO(zzimCardResponses.size(), zzimCardResponses);
     }
 
-    private ZzimCardListResponseDTO getZzimByArea(Long userId, Double longitude, Double latitude) {
+    private ZzimCardListResponseDTO getZzimByAreaDong(Long userId, Double longitude, Double latitude) {
         List<ZzimPostEntity> zzimPostEntityList = zzimPostRepository.findByUser(userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorMessage.USER_NOT_FOUND))
         );
@@ -269,14 +271,76 @@ public class ZzimPostService {
             }
         }
 
-        // 주어진 위도(latitude)와 경도(longitude) 기준으로 10km 이내 장소만 필터링
+        // 주어진 위도(latitude)와 경도(longitude) 기준으로 1km 이내 장소만 필터링
         List<ZzimCardResponseDTO> zzimCardResponses = uniquePlacePostMap.values().stream()
                 .filter(zzimPostEntity -> {
                     PlaceEntity placeEntity = zzimPostEntity.getPost().getPlace();
                     if (placeEntity.getLatitude() == null || placeEntity.getLongitude() == null) {
                         return false;
                     }
-                    return calculateDistance(latitude, longitude, placeEntity.getLatitude(), placeEntity.getLongitude()) <= 10.0;
+                    return calculateDistance(latitude, longitude, placeEntity.getLatitude(), placeEntity.getLongitude()) <= 1.0;
+                })
+                .map(zzimPostEntity -> {
+                    PostEntity postEntity = zzimPostEntity.getPost();
+                    PlaceEntity placeEntity = postEntity.getPlace();
+
+                    PhotoEntity photoEntity = photoRepository.findFirstByPost(postEntity)
+                            .orElseThrow(() -> new BusinessException(PostErrorMessage.PHOTO_NOT_FOUND));
+
+                    CategoryColorResponseDTO categoryColorResponse = postCategoryRepository.findByPost(postEntity)
+                            .map(PostCategoryEntity::getCategory)
+                            .map(categoryEntity -> new CategoryColorResponseDTO(
+                                    categoryEntity.getCategoryId(),
+                                    categoryEntity.getCategoryName(),
+                                    categoryEntity.getIconUrlColor(),
+                                    categoryEntity.getTextColor(),
+                                    categoryEntity.getBackgroundColor()
+                            ))
+                            .orElseThrow(() -> new BusinessException(PostErrorMessage.CATEGORY_NOT_FOUND));
+
+                    return new ZzimCardResponseDTO(
+                            placeEntity.getPlaceId(),  // placeId 추가
+                            placeEntity.getPlaceName(),
+                            placeEntity.getPlaceAddress(),
+                            postEntity.getTitle(),
+                            photoEntity.getPhotoUrl(),
+                            placeEntity.getLatitude(),
+                            placeEntity.getLongitude(),
+                            categoryColorResponse
+                    );
+                })
+                .collect(Collectors.toList());
+
+        return new ZzimCardListResponseDTO(zzimCardResponses.size(), zzimCardResponses);
+    }
+
+    private ZzimCardListResponseDTO getZzimByAreaStation(Long userId, Double longitude, Double latitude) {
+        List<ZzimPostEntity> zzimPostEntityList = zzimPostRepository.findByUser(userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorMessage.USER_NOT_FOUND))
+        );
+
+        Map<Long, ZzimPostEntity> uniquePlacePostMap = new LinkedHashMap<>();
+
+        for (ZzimPostEntity zzimPostEntity : zzimPostEntityList) {
+            PlaceEntity placeEntity = zzimPostEntity.getPost().getPlace();
+            if (placeEntity == null) {
+                throw new BusinessException(PlaceErrorMessage.PLACE_NOT_FOUND);
+            }
+
+            Long placeId = placeEntity.getPlaceId();
+            if (!uniquePlacePostMap.containsKey(placeId)) {
+                uniquePlacePostMap.put(placeId, zzimPostEntity);
+            }
+        }
+
+        // 주어진 위도(latitude)와 경도(longitude) 기준으로 1km 이내 장소만 필터링
+        List<ZzimCardResponseDTO> zzimCardResponses = uniquePlacePostMap.values().stream()
+                .filter(zzimPostEntity -> {
+                    PlaceEntity placeEntity = zzimPostEntity.getPost().getPlace();
+                    if (placeEntity.getLatitude() == null || placeEntity.getLongitude() == null) {
+                        return false;
+                    }
+                    return calculateDistance(latitude, longitude, placeEntity.getLatitude(), placeEntity.getLongitude()) <= 2.0;
                 })
                 .map(zzimPostEntity -> {
                     PostEntity postEntity = zzimPostEntity.getPost();


### PR DESCRIPTION
### 📝 Work Description
- 기존에는 구, 동은 주소 기준으로 검색하고, 역은 거리 기준으로 검색하는 로직으로 구현 예정이었습니다.
- 하지만 네이버 장소 검색 API에서 반환되는 주소 값에 동이 포함되지 않는 경우가 발견되었고, 임시로 동 검색 기준을 거리 기준으로 변경하였습니다.

### ⚙️ Issue
[//]: # (연관된 이슈 번호)
- closed #85 

### 🔨 Changes
- 구는 주소 기준 검색, 동은 거리 기준 2km, 역은 거리 기준 1km

### 🔍 PR Point
- 수학적인 로직에 실수가 있을 수도 있어서 검토해주시면 감사하겠습니다!