### PR TITLE
[FEAT] 사용자 피드 업데이트 비동기 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/feed/FeedPersistenceAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/feed/FeedPersistenceAdapter.java
@@ -28,6 +28,11 @@ public class FeedPersistenceAdapter implements FeedPort {
     private final PostRepository postRepository;
 
     @Override
+    public void saveFollowerFeed(Long userId, Long postId) {
+
+    }
+
+    @Override
     public List<Feed> findFeedByUserId(Long userId) {
         return feedRepository.findByUser_UserId(userId)
                 .stream()

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/feed/db/FeedEntity.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/feed/db/FeedEntity.java
@@ -26,8 +26,7 @@ public class FeedEntity {
     private PostEntity post;
 
     @Builder
-    public FeedEntity(Long feedId, UserEntity user, PostEntity post) {
-        this.feedId = feedId;
+    public FeedEntity(UserEntity user, PostEntity post) {
         this.user = user;
         this.post = post;
     }

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/feed/event/PostCreatedEventListener.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/feed/event/PostCreatedEventListener.java
@@ -1,0 +1,54 @@
+package com.spoony.spoony_server.adapter.out.persistence.feed.event;
+
+import com.spoony.spoony_server.adapter.out.persistence.feed.db.FeedEntity;
+import com.spoony.spoony_server.adapter.out.persistence.feed.db.FeedRepository;
+import com.spoony.spoony_server.adapter.out.persistence.post.db.PostEntity;
+import com.spoony.spoony_server.adapter.out.persistence.post.db.PostRepository;
+import com.spoony.spoony_server.adapter.out.persistence.user.db.UserEntity;
+import com.spoony.spoony_server.adapter.out.persistence.user.db.UserRepository;
+import com.spoony.spoony_server.application.event.PostCreatedEvent;
+import com.spoony.spoony_server.global.annotation.Adapter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+
+import java.util.List;
+import java.util.concurrent.Executors;
+
+@Adapter
+@RequiredArgsConstructor
+public class PostCreatedEventListener {
+
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final FeedRepository feedRepository;
+
+    @EventListener
+    public void handlePostCreatedEvent(PostCreatedEvent event) {
+        List<Long> followerIds = event.getFollowerIds();
+        Long postId = event.getPostId();
+
+        PostEntity postEntity = postRepository.findById(postId)
+                .orElseThrow();
+
+        int batchSize = 10_000;
+
+        var executor = Executors.newVirtualThreadPerTaskExecutor();
+        for (int i = 0; i < followerIds.size(); i += batchSize) {
+            int fromIndex = i;
+            int toIndex = Math.min(i + batchSize, followerIds.size());
+
+            executor.submit(() -> {
+                List<FeedEntity> feedList = followerIds.subList(fromIndex, toIndex).stream()
+                        .map(followerId -> {
+                            UserEntity userEntity = userRepository.findById(followerId)
+                                    .orElseThrow();
+                            return new FeedEntity(userEntity, postEntity);
+                        })
+                        .toList();
+
+                feedRepository.saveAll(feedList);
+            });
+        }
+        executor.shutdown();
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/application/event/PostCreatedEvent.java
+++ b/src/main/java/com/spoony/spoony_server/application/event/PostCreatedEvent.java
@@ -1,0 +1,18 @@
+package com.spoony.spoony_server.application.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+import java.util.List;
+
+@Getter
+public class PostCreatedEvent extends ApplicationEvent {
+    private final List<Long> followerIds;
+    private final Long postId;
+
+    public PostCreatedEvent(Object source, List<Long> followerIds, Long postId) {
+        super(source);
+        this.followerIds = followerIds;
+        this.postId = postId;
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/application/port/out/feed/FeedPort.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/out/feed/FeedPort.java
@@ -9,5 +9,6 @@ import java.util.List;
 public interface FeedPort {
     List<Feed> findFeedByUserId(Long userId);
     void saveFollowersFeed(List<Follow> followList, Post post);
+    void saveFollowerFeed(Long userId, Long postId);
     void deleteFeedByUserIdAndPostId(Long userId, Long postId);
 }

--- a/src/main/java/com/spoony/spoony_server/config/AsyncConfig.java
+++ b/src/main/java/com/spoony/spoony_server/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.spoony.spoony_server.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}


### PR DESCRIPTION
### 📝 Work Description
- 팔로워 피드 업데이트를 이벤트를 발행하는 방식으로 변경하였습니다.
- Spring Event를 사용하였고, Java 21에서 제공하는 Virtual Thread를 사용했습니다.

### ⚙️ Issue
[//]: # (연관된 이슈 번호)
- closed #96 

### 🔨 Changes
- 기존에는 `createPost` 메서드에서 피드 업데이트까지 완료하였지만, 이제 단순히 이벤트를 발행하는 방식으로 변경되었습니다.

### 🔍 PR Point
- JVM에서 관리하는 경량 스레드인 Virtual Thread의 장점을 알아보고, OS Thread와 비교해보는 시간을 가지면 좋을 것 같습니다!