### PR TITLE
[FEAT] Apple 소셜 로그인 인증 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ out/
 application.yml
 application-aws.yml
 application-naver.yml
+application-oath.yml

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.4.1'
+    id 'org.springframework.boot' version '3.3.1'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -30,6 +30,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.2'
+    implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
+    implementation 'org.bouncycastle:bcpkix-jdk15on:1.70'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/dto/request/UserLoginDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/dto/request/UserLoginDTO.java
@@ -3,8 +3,5 @@ package com.spoony.spoony_server.adapter.auth.dto.request;
 import com.spoony.spoony_server.domain.user.Platform;
 import jakarta.validation.constraints.NotNull;
 
-public record UserLoginDTO(
-    @NotNull
-    Platform platform
-) {
+public record UserLoginDTO(@NotNull Platform platform) {
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/dto/response/JwtTokenDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/dto/response/JwtTokenDTO.java
@@ -4,10 +4,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 
 @Builder(access = AccessLevel.PRIVATE)
-public record JwtTokenDTO(
-        String accessToken,
-        String refreshToken
-) {
+public record JwtTokenDTO(String accessToken,
+                          String refreshToken) {
     public static JwtTokenDTO of(String accessToken, String refreshToken) {
         return JwtTokenDTO.builder()
                 .accessToken(accessToken)

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/dto/response/UserTokenDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/dto/response/UserTokenDTO.java
@@ -2,10 +2,8 @@ package com.spoony.spoony_server.adapter.auth.dto.response;
 
 import com.spoony.spoony_server.domain.user.User;
 
-public record UserTokenDTO(
-        String name,
-        JwtTokenDTO jwtTokenDto
-) {
+public record UserTokenDTO(String name,
+                           JwtTokenDTO jwtTokenDto) {
     public static UserTokenDTO of(User user, JwtTokenDTO jwtTokenDTO) {
         return new UserTokenDTO(
                 user.getUserName(),

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/dto/validation/ApplePublicKeyDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/dto/validation/ApplePublicKeyDTO.java
@@ -1,0 +1,10 @@
+package com.spoony.spoony_server.adapter.auth.dto.validation;
+
+public record ApplePublicKeyDTO(String kty,
+                                String kid,
+                                String use,
+                                String alg,
+                                String n,
+                                String e,
+                                String email) {
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/dto/validation/ApplePublicKeyListDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/dto/validation/ApplePublicKeyListDTO.java
@@ -1,0 +1,16 @@
+package com.spoony.spoony_server.adapter.auth.dto.validation;
+
+import com.spoony.spoony_server.global.exception.AuthException;
+import com.spoony.spoony_server.global.message.auth.AuthErrorMessage;
+
+import java.util.List;
+
+public record ApplePublicKeyListDTO(List<ApplePublicKeyDTO> keys) {
+    public ApplePublicKeyDTO getMatchesKey(String alg, String kid) {
+        return this.keys
+                .stream()
+                .filter(k -> k.alg().equals(alg) && k.kid().equals(kid))
+                .findFirst()
+                .orElseThrow(() -> new AuthException(AuthErrorMessage.INVALID_APPLE_PUBLIC_KEY));
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/dto/validation/AppleTokenDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/dto/validation/AppleTokenDTO.java
@@ -1,0 +1,12 @@
+package com.spoony.spoony_server.adapter.auth.dto.validation;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record AppleTokenDTO(String accessToken,
+                            String tokenType,
+                            String expiresIn,
+                            String refreshToken,
+                            String idToken) {
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/out/external/AppleFeignClient.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/out/external/AppleFeignClient.java
@@ -1,0 +1,32 @@
+package com.spoony.spoony_server.adapter.auth.out.external;
+
+import com.spoony.spoony_server.adapter.auth.dto.validation.ApplePublicKeyListDTO;
+import com.spoony.spoony_server.adapter.auth.dto.validation.AppleTokenDTO;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "apple-public-key-client", url = "https://appleid.apple.com/auth")
+public interface AppleFeignClient {
+
+    @GetMapping("/keys")
+    ApplePublicKeyListDTO getApplePublicKeys();
+
+    @PostMapping(value = "/token", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    AppleTokenDTO getAppleToken(
+            @RequestParam("client_id") String clientId,
+            @RequestParam("client_secret") String clientSecret,
+            @RequestParam("grant_type") String grantType,
+            @RequestParam("code") String authCode
+    );
+
+    @PostMapping(value = "/revoke", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    void revoke(
+            @RequestParam(value = "client_id") String client_id,
+            @RequestParam(value = "client_secret") String client_secret,
+            @RequestParam(value = "token") String token,
+            @RequestParam(value = "token_type_hint") String token_type_hint
+    );
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/validation/AppleClientSecretGenerator.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/validation/AppleClientSecretGenerator.java
@@ -1,0 +1,71 @@
+package com.spoony.spoony_server.adapter.auth.validation;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.PrivateKey;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Component
+public class AppleClientSecretGenerator {
+
+    private static final String SIGN_ALGORITHM_HEADER_KEY = "alg";
+    private static final String KEY_ID_HEADER_KEY = "kid";
+    private static final String AUDIENCE = "https://appleid.apple.com";
+
+    @Value("${oauth.apple.team-id}")
+    private String teamId;
+
+    @Value("${oauth.apple.client-id}")
+    private String clientId;
+
+    @Value("${oauth.apple.key-id}")
+    private String keyId;
+
+    @Value("${oauth.apple.key-path}")
+    private String keyPath;
+
+    public String createClientSecret() throws IOException {
+        Date expirationDate = Date.from(LocalDateTime.now().plusDays(30).atZone(ZoneId.systemDefault()).toInstant());
+        Map<String, Object> jwtHeader = new HashMap<>();
+        jwtHeader.put(KEY_ID_HEADER_KEY, keyId); // kid
+        jwtHeader.put(SIGN_ALGORITHM_HEADER_KEY, SignatureAlgorithm.ES256); // alg
+        return Jwts.builder()
+                .setHeaderParams(jwtHeader)
+                .setIssuer(teamId) // iss
+                .setIssuedAt(new Date(System.currentTimeMillis())) // 발행 시간
+                .setExpiration(expirationDate) // 만료 시간
+                .setAudience(AUDIENCE) // aud
+                .setSubject(clientId) // sub
+                .signWith(SignatureAlgorithm.ES256, getPrivateKey())
+                .compact();
+    }
+
+    public PrivateKey getPrivateKey() throws IOException {
+        ClassPathResource resource = new ClassPathResource(keyPath); // .p8 key파일 위치
+        String privateKey = new String(Files.readAllBytes(Paths.get(resource.getURI())));
+
+        Reader pemReader = new StringReader(privateKey);
+        PEMParser pemParser = new PEMParser(pemReader);
+        JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
+        PrivateKeyInfo object = (PrivateKeyInfo) pemParser.readObject();
+        return converter.getPrivateKey(object);
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/validation/AppleJwtParser.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/validation/AppleJwtParser.java
@@ -1,0 +1,45 @@
+package com.spoony.spoony_server.adapter.auth.validation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spoony.spoony_server.global.exception.AuthException;
+import com.spoony.spoony_server.global.message.auth.AuthErrorMessage;
+import io.jsonwebtoken.*;
+import org.springframework.stereotype.Component;
+
+import java.security.PublicKey;
+import java.util.Base64;
+import java.util.Map;
+
+@Component
+public class AppleJwtParser {
+
+    private static final String IDENTITY_TOKEN_VALUE_DELIMITER = "\\.";
+    private static final int HEADER_INDEX = 0;
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    public Map<String, String> parseHeaders(String identityToken) {
+        try {
+            String encodedHeader = identityToken.split(IDENTITY_TOKEN_VALUE_DELIMITER)[HEADER_INDEX];
+            String decodedHeader = new String(Base64.getUrlDecoder().decode(encodedHeader));
+            return OBJECT_MAPPER.readValue(decodedHeader, Map.class);
+        } catch (JsonProcessingException | ArrayIndexOutOfBoundsException e) {
+            throw new AuthException(AuthErrorMessage.INVALID_APPLE_IDENTITY_TOKEN);
+        }
+    }
+
+    public Claims parsePublicKeyAndGetClaims(String idToken, PublicKey publicKey) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(publicKey)
+                    .build()
+                    .parseClaimsJws(idToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            throw new AuthException(AuthErrorMessage.EXPIRED_APPLE_IDENTITY_TOKEN);
+        } catch (UnsupportedJwtException | MalformedJwtException | IllegalArgumentException e) {
+            throw new AuthException(AuthErrorMessage.INVALID_APPLE_IDENTITY_TOKEN);
+        }
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/validation/ApplePublicKeyGenerator.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/validation/ApplePublicKeyGenerator.java
@@ -1,0 +1,49 @@
+package com.spoony.spoony_server.adapter.auth.validation;
+
+import com.spoony.spoony_server.adapter.auth.dto.validation.ApplePublicKeyDTO;
+import com.spoony.spoony_server.adapter.auth.dto.validation.ApplePublicKeyListDTO;
+import com.spoony.spoony_server.global.exception.AuthException;
+import com.spoony.spoony_server.global.message.auth.AuthErrorMessage;
+import org.springframework.stereotype.Component;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Map;
+
+@Component
+public class ApplePublicKeyGenerator {
+
+    private static final String SIGN_ALGORITHM_HEADER_KEY = "alg";
+    private static final String KEY_ID_HEADER_KEY = "kid";
+    private static final int POSITIVE_SIGN_NUMBER = 1;
+
+    public PublicKey generatePublicKey(Map<String, String> headers, ApplePublicKeyListDTO applePublicKeyListDTO) {
+        ApplePublicKeyDTO applePublicKeyDTO = applePublicKeyListDTO.getMatchesKey(
+                headers.get(SIGN_ALGORITHM_HEADER_KEY),
+                headers.get(KEY_ID_HEADER_KEY));
+
+        return generatePublicKeyWithApplePublicKey(applePublicKeyDTO);
+    }
+
+    private PublicKey generatePublicKeyWithApplePublicKey(ApplePublicKeyDTO applePublicKeyDTO) {
+        byte[] nBytes = Base64.getUrlDecoder().decode(applePublicKeyDTO.n());
+        byte[] eBytes = Base64.getUrlDecoder().decode(applePublicKeyDTO.e());
+
+        BigInteger n = new BigInteger(POSITIVE_SIGN_NUMBER, nBytes);
+        BigInteger e = new BigInteger(POSITIVE_SIGN_NUMBER, eBytes);
+
+        RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(n, e);
+
+        try {
+            KeyFactory keyFactory = KeyFactory.getInstance(applePublicKeyDTO.kty());
+            return keyFactory.generatePublic(publicKeySpec);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException exception) {
+            throw new AuthException(AuthErrorMessage.CREATE_PUBLIC_KEY_EXCEPTION);
+        }
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/application/auth/service/AppleService.java
+++ b/src/main/java/com/spoony/spoony_server/application/auth/service/AppleService.java
@@ -1,0 +1,76 @@
+package com.spoony.spoony_server.application.auth.service;
+
+import com.spoony.spoony_server.adapter.auth.dto.PlatformUserDTO;
+import com.spoony.spoony_server.adapter.auth.dto.validation.ApplePublicKeyListDTO;
+import com.spoony.spoony_server.adapter.auth.dto.validation.AppleTokenDTO;
+import com.spoony.spoony_server.adapter.auth.out.external.AppleFeignClient;
+import com.spoony.spoony_server.adapter.auth.validation.AppleClientSecretGenerator;
+import com.spoony.spoony_server.adapter.auth.validation.AppleJwtParser;
+import com.spoony.spoony_server.adapter.auth.validation.ApplePublicKeyGenerator;
+import com.spoony.spoony_server.global.exception.AuthException;
+import com.spoony.spoony_server.global.exception.BusinessException;
+import com.spoony.spoony_server.global.message.auth.AuthErrorMessage;
+import com.spoony.spoony_server.global.message.business.BusinessErrorMessage;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.security.PublicKey;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class AppleService {
+
+    private final String APPLE_SUBJECT = "sub";
+    private final String APPLE_EMAIL = "email";
+
+    @Value("${oauth.apple.client-id}")
+    private String clientId;
+
+    private final AppleFeignClient appleFeignClient;
+    private final AppleJwtParser appleJwtParser;
+    private final ApplePublicKeyGenerator applePublicKeyGenerator;
+    private final AppleClientSecretGenerator appleClientSecretGenerator;
+
+    public PlatformUserDTO getPlatformUserInfo(String platformToken) {
+        Map<String, String> headers = appleJwtParser.parseHeaders(platformToken);
+        ApplePublicKeyListDTO applePublicKeys = appleFeignClient.getApplePublicKeys();
+        PublicKey publicKey = applePublicKeyGenerator.generatePublicKey(headers, applePublicKeys);
+        Claims claims = appleJwtParser.parsePublicKeyAndGetClaims(platformToken, publicKey);
+        return PlatformUserDTO.of(claims.get(APPLE_SUBJECT, String.class), claims.get(APPLE_EMAIL, String.class));
+    }
+
+    public void revoke(final String authCode) {
+        if (authCode == null || authCode.isEmpty()) {
+            throw new BusinessException(BusinessErrorMessage.MISSING_REQUIRED_HEADER);
+        }
+        try {
+            String clientSecret = appleClientSecretGenerator.createClientSecret();
+            String refreshToken = getRefreshToken(authCode, clientSecret);
+            appleFeignClient.revoke(
+                    clientId,
+                    clientSecret,
+                    refreshToken,
+                    "refresh_token"
+            );
+        } catch (Exception e){
+            throw new AuthException(AuthErrorMessage.APPLE_REVOKE_FAILED);
+        }
+    }
+
+    private String getRefreshToken(final String authCode, final String clientSecret) {
+        try {
+            AppleTokenDTO appleTokenDTO = appleFeignClient.getAppleToken(
+                    clientId,
+                    clientSecret,
+                    "authorization_code",
+                    authCode
+            );
+            return appleTokenDTO.refreshToken();
+        } catch (Exception e){
+            throw new AuthException(AuthErrorMessage.APPLE_TOKEN_REQUEST_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/application/auth/service/AuthService.java
+++ b/src/main/java/com/spoony/spoony_server/application/auth/service/AuthService.java
@@ -22,6 +22,7 @@ public class AuthService implements SignInUseCase {
 
     private final UserPort userPort;
     private final JwtTokenProvider jwtTokenProvider;
+    private final AppleService appleService;
 
     @Override
     public UserTokenDTO signIn(String platformToken, UserLoginDTO userLoginDTO) {
@@ -33,10 +34,10 @@ public class AuthService implements SignInUseCase {
     }
 
     private PlatformUserDTO getPlatformInfo(String platformToken, UserLoginDTO userLoginDto) {
-        if (userLoginDto.platform().toString().equals("GOOGLE")){
+        if (userLoginDto.platform().toString().equals("KAKAO")){
             //TODO
         } else if (userLoginDto.platform().toString().equals("APPLE")){
-            //TODO
+            return appleService.getPlatformUserInfo(platformToken);
         } else {
             throw new AuthException(AuthErrorMessage.PLATFORM_NOT_FOUND);
         }

--- a/src/main/java/com/spoony/spoony_server/config/FeignClientConfig.java
+++ b/src/main/java/com/spoony/spoony_server/config/FeignClientConfig.java
@@ -1,0 +1,10 @@
+package com.spoony.spoony_server.config;
+
+import com.spoony.spoony_server.SpoonyServerApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients(basePackageClasses = SpoonyServerApplication.class)
+public class FeignClientConfig {
+}

--- a/src/main/java/com/spoony/spoony_server/global/message/auth/AuthErrorMessage.java
+++ b/src/main/java/com/spoony/spoony_server/global/message/auth/AuthErrorMessage.java
@@ -5,7 +5,13 @@ import org.springframework.http.HttpStatus;
 
 public enum AuthErrorMessage implements DefaultErrorMessage {
     PLATFORM_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "유효하지 않은 소셜 플랫폼입니다."),
-    UNAUTHORIZED(HttpStatus.INTERNAL_SERVER_ERROR, "인증되지 않은 사용자입니다.");
+    UNAUTHORIZED(HttpStatus.INTERNAL_SERVER_ERROR, "인증되지 않은 사용자입니다."),
+    INVALID_APPLE_PUBLIC_KEY(HttpStatus.INTERNAL_SERVER_ERROR, "유효하지 않은 Apple Public Key입니다."),
+    INVALID_APPLE_IDENTITY_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "유효하지 않은 Apple Identity Token입니다."),
+    EXPIRED_APPLE_IDENTITY_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "만료된 Apple Identity Token입니다."),
+    CREATE_PUBLIC_KEY_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "Apple Public Key 생성에 실패하였습니다."),
+    APPLE_REVOKE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Apple 회원 탈퇴에 실패하였습니다."),
+    APPLE_TOKEN_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Apple 토큰 요청에 실패하였습니다.");
 
     private HttpStatus httpStatus;
     private String message;


### PR DESCRIPTION
### 📝 Work Description
- Apple 소셜 로그인 인증을 구현하였습니다.
- `appleJwtParser`를 통해 Apple Identity Token이 유효한지 검증합니다.
- `appleFeignClient`를 통해 Apple Public Key 리스트를 가져옵니다.
- `applePublicKeyGenerator`를 통해 올바른 Public Key를 찾고, 생성합니다.
- `appleJwtParser`를 통해 사용자 정보(`Claim`)을 추출합니다. 

### ⚙️ Issue
[//]: # (연관된 이슈 번호)
- closed #100 

### 🔨 Changes
- Apple Service가 구체화되었습니다.

### 🔍 PR Point
- Apple API 통신에서 기존 방식과 달리 FeignClient를 사용하게 되면서, Spring의 버전을 `3.3.1`로 낮추게 되었습니다.
- Naver API 통신 또한 FeignClient를 사용하여 코드를 간소화하는 방향을 검토 중입니다.