### PR TITLE
[FEAT] Kakao 소셜 로그인 인증 구현

### DIFF
--- a/src/main/java/com/spoony/spoony_server/adapter/auth/dto/validation/apple/ApplePublicKeyDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/dto/validation/apple/ApplePublicKeyDTO.java
@@ -1,4 +1,4 @@
-package com.spoony.spoony_server.adapter.auth.dto.validation;
+package com.spoony.spoony_server.adapter.auth.dto.validation.apple;
 
 public record ApplePublicKeyDTO(String kty,
                                 String kid,

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/dto/validation/apple/ApplePublicKeyListDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/dto/validation/apple/ApplePublicKeyListDTO.java
@@ -1,4 +1,4 @@
-package com.spoony.spoony_server.adapter.auth.dto.validation;
+package com.spoony.spoony_server.adapter.auth.dto.validation.apple;
 
 import com.spoony.spoony_server.global.exception.AuthException;
 import com.spoony.spoony_server.global.message.auth.AuthErrorMessage;

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/dto/validation/apple/AppleTokenDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/dto/validation/apple/AppleTokenDTO.java
@@ -1,4 +1,4 @@
-package com.spoony.spoony_server.adapter.auth.dto.validation;
+package com.spoony.spoony_server.adapter.auth.dto.validation.apple;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/dto/validation/kakao/KakaoAccount.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/dto/validation/kakao/KakaoAccount.java
@@ -1,0 +1,4 @@
+package com.spoony.spoony_server.adapter.auth.dto.validation.kakao;
+
+public record KakaoAccount(String email) {
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/dto/validation/kakao/KakaoUserDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/dto/validation/kakao/KakaoUserDTO.java
@@ -1,0 +1,9 @@
+package com.spoony.spoony_server.adapter.auth.dto.validation.kakao;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record KakaoUserDTO(Long id,
+                           KakaoAccount kakaoAccount) {
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/out/external/AppleFeignClient.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/out/external/AppleFeignClient.java
@@ -1,7 +1,7 @@
 package com.spoony.spoony_server.adapter.auth.out.external;
 
-import com.spoony.spoony_server.adapter.auth.dto.validation.ApplePublicKeyListDTO;
-import com.spoony.spoony_server.adapter.auth.dto.validation.AppleTokenDTO;
+import com.spoony.spoony_server.adapter.auth.dto.validation.apple.ApplePublicKeyListDTO;
+import com.spoony.spoony_server.adapter.auth.dto.validation.apple.AppleTokenDTO;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/out/external/KakaoFeignClient.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/out/external/KakaoFeignClient.java
@@ -1,0 +1,22 @@
+package com.spoony.spoony_server.adapter.auth.out.external;
+
+import com.spoony.spoony_server.adapter.auth.dto.validation.kakao.KakaoUserDTO;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "kakaoFeignClient", url = "https://kapi.kakao.com")
+public interface KakaoFeignClient {
+    @GetMapping(value = "/v2/user/me")
+    KakaoUserDTO getUserInformation(@RequestHeader(HttpHeaders.AUTHORIZATION) String accessToken);
+
+    @PostMapping(value = "/v1/user/unlink")
+    void unlinkUser(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String adminKey,
+            @RequestParam("target_id_type") String targetIdType,
+            @RequestParam("target_id") Long targetId
+    );
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/validation/apple/AppleClientSecretGenerator.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/validation/apple/AppleClientSecretGenerator.java
@@ -1,4 +1,4 @@
-package com.spoony.spoony_server.adapter.auth.validation;
+package com.spoony.spoony_server.adapter.auth.validation.apple;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/validation/apple/AppleJwtParser.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/validation/apple/AppleJwtParser.java
@@ -1,4 +1,4 @@
-package com.spoony.spoony_server.adapter.auth.validation;
+package com.spoony.spoony_server.adapter.auth.validation.apple;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/validation/apple/ApplePublicKeyGenerator.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/validation/apple/ApplePublicKeyGenerator.java
@@ -1,7 +1,7 @@
-package com.spoony.spoony_server.adapter.auth.validation;
+package com.spoony.spoony_server.adapter.auth.validation.apple;
 
-import com.spoony.spoony_server.adapter.auth.dto.validation.ApplePublicKeyDTO;
-import com.spoony.spoony_server.adapter.auth.dto.validation.ApplePublicKeyListDTO;
+import com.spoony.spoony_server.adapter.auth.dto.validation.apple.ApplePublicKeyDTO;
+import com.spoony.spoony_server.adapter.auth.dto.validation.apple.ApplePublicKeyListDTO;
 import com.spoony.spoony_server.global.exception.AuthException;
 import com.spoony.spoony_server.global.message.auth.AuthErrorMessage;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/spoony/spoony_server/application/auth/service/AppleService.java
+++ b/src/main/java/com/spoony/spoony_server/application/auth/service/AppleService.java
@@ -1,12 +1,12 @@
 package com.spoony.spoony_server.application.auth.service;
 
 import com.spoony.spoony_server.adapter.auth.dto.PlatformUserDTO;
-import com.spoony.spoony_server.adapter.auth.dto.validation.ApplePublicKeyListDTO;
-import com.spoony.spoony_server.adapter.auth.dto.validation.AppleTokenDTO;
+import com.spoony.spoony_server.adapter.auth.dto.validation.apple.ApplePublicKeyListDTO;
+import com.spoony.spoony_server.adapter.auth.dto.validation.apple.AppleTokenDTO;
 import com.spoony.spoony_server.adapter.auth.out.external.AppleFeignClient;
-import com.spoony.spoony_server.adapter.auth.validation.AppleClientSecretGenerator;
-import com.spoony.spoony_server.adapter.auth.validation.AppleJwtParser;
-import com.spoony.spoony_server.adapter.auth.validation.ApplePublicKeyGenerator;
+import com.spoony.spoony_server.adapter.auth.validation.apple.AppleClientSecretGenerator;
+import com.spoony.spoony_server.adapter.auth.validation.apple.AppleJwtParser;
+import com.spoony.spoony_server.adapter.auth.validation.apple.ApplePublicKeyGenerator;
 import com.spoony.spoony_server.global.exception.AuthException;
 import com.spoony.spoony_server.global.exception.BusinessException;
 import com.spoony.spoony_server.global.message.auth.AuthErrorMessage;

--- a/src/main/java/com/spoony/spoony_server/application/auth/service/AuthService.java
+++ b/src/main/java/com/spoony/spoony_server/application/auth/service/AuthService.java
@@ -23,6 +23,7 @@ public class AuthService implements SignInUseCase {
     private final UserPort userPort;
     private final JwtTokenProvider jwtTokenProvider;
     private final AppleService appleService;
+    private final KakaoService kakaoService;
 
     @Override
     public UserTokenDTO signIn(String platformToken, UserLoginDTO userLoginDTO) {
@@ -35,13 +36,12 @@ public class AuthService implements SignInUseCase {
 
     private PlatformUserDTO getPlatformInfo(String platformToken, UserLoginDTO userLoginDto) {
         if (userLoginDto.platform().toString().equals("KAKAO")){
-            //TODO
+            return kakaoService.getPlatformUserInfo(platformToken);
         } else if (userLoginDto.platform().toString().equals("APPLE")){
             return appleService.getPlatformUserInfo(platformToken);
         } else {
             throw new AuthException(AuthErrorMessage.PLATFORM_NOT_FOUND);
         }
-        return null;
     }
 
     private User loadOrCreate(Platform platform, PlatformUserDTO platformUserDTO) {

--- a/src/main/java/com/spoony/spoony_server/application/auth/service/KakaoService.java
+++ b/src/main/java/com/spoony/spoony_server/application/auth/service/KakaoService.java
@@ -1,0 +1,34 @@
+package com.spoony.spoony_server.application.auth.service;
+
+import com.spoony.spoony_server.adapter.auth.dto.PlatformUserDTO;
+import com.spoony.spoony_server.adapter.auth.dto.validation.kakao.KakaoUserDTO;
+import com.spoony.spoony_server.adapter.auth.out.external.KakaoFeignClient;
+import com.spoony.spoony_server.global.constant.AuthConstant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+
+    @Value("${oauth.kakao.admin-key}")
+    private String adminKey;
+
+    private final KakaoFeignClient kakaoFeignClient;
+
+    public PlatformUserDTO getPlatformUserInfo(String providerToken) {
+        KakaoUserDTO kakaoUserDTO = kakaoFeignClient.getUserInformation(AuthConstant.BEARER_TOKEN_PREFIX + providerToken);
+        return PlatformUserDTO.of(
+                kakaoUserDTO.id().toString(),
+                kakaoUserDTO.kakaoAccount().email());
+    }
+
+    public void unlinkKakaoUser(final String providerId) {
+        kakaoFeignClient.unlinkUser(
+                AuthConstant.GRANT_TYPE + adminKey,
+                AuthConstant.TARGET_ID_TYPE,
+                Long.valueOf(providerId)
+        );
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/global/constant/AuthConstant.java
+++ b/src/main/java/com/spoony/spoony_server/global/constant/AuthConstant.java
@@ -10,6 +10,10 @@ public class AuthConstant {
     public static final String BEARER_TOKEN_PREFIX = "Bearer ";
     public static final String CHARACTER_ENCODING_UTF8 = "utf-8";
 
-    // Apple
+    // KAKAO
+    public static final String GRANT_TYPE = "KakaoAK ";
+    public static final String TARGET_ID_TYPE = "user_id";
+
+    // APPLE
     public static final String APPLE_WITHDRAW_HEADER = "X-Apple-Code";
 }


### PR DESCRIPTION
### 📝 Work Description
- Kakao Service를 구현하였고, `FeignClient`를 통해 카카오 서버에 요청을 진행하였습니다.
- 카카오 사용자 정보를 추출하는 메서드와, 카카오 사용자 연결을 해제하는 메서드를 구현하였습니다.

### ⚙️ Issue
[//]: # (연관된 이슈 번호)
- closed #102 

### 🔨 Changes
- Kakao Service가 구현되었습니다.