### PR TITLE
[FEAT] 소셜 로그인 회원가입 & 토큰 발행 구현

### DIFF
--- a/src/main/java/com/spoony/spoony_server/adapter/auth/dto/request/UserLoginDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/dto/request/UserLoginDTO.java
@@ -3,5 +3,8 @@ package com.spoony.spoony_server.adapter.auth.dto.request;
 import com.spoony.spoony_server.domain.user.Platform;
 import jakarta.validation.constraints.NotNull;
 
-public record UserLoginDTO(@NotNull Platform platform) {
+public record UserLoginDTO(@NotNull Platform platform,
+                           @NotNull String userName,
+                           @NotNull String userImage,
+                           @NotNull Long regionId) {
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/dto/response/UserTokenDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/dto/response/UserTokenDTO.java
@@ -2,11 +2,11 @@ package com.spoony.spoony_server.adapter.auth.dto.response;
 
 import com.spoony.spoony_server.domain.user.User;
 
-public record UserTokenDTO(String name,
+public record UserTokenDTO(User user,
                            JwtTokenDTO jwtTokenDto) {
     public static UserTokenDTO of(User user, JwtTokenDTO jwtTokenDTO) {
         return new UserTokenDTO(
-                user.getUserName(),
+                user,
                 jwtTokenDTO
         );
     }

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/in/web/AuthController.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/in/web/AuthController.java
@@ -1,29 +1,39 @@
 package com.spoony.spoony_server.adapter.auth.in.web;
 
 import com.spoony.spoony_server.adapter.auth.dto.request.UserLoginDTO;
+import com.spoony.spoony_server.adapter.auth.dto.response.JwtTokenDTO;
 import com.spoony.spoony_server.adapter.auth.dto.response.UserTokenDTO;
+import com.spoony.spoony_server.application.auth.port.in.RefreshUseCase;
 import com.spoony.spoony_server.application.auth.port.in.SignInUseCase;
 import com.spoony.spoony_server.global.constant.AuthConstant;
+import com.spoony.spoony_server.global.dto.ResponseDTO;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
 public class AuthController {
 
     private final SignInUseCase signInUseCase;
+    private final RefreshUseCase refreshUseCase;
 
-    @PostMapping("/v1/auth/signin")
-    public ResponseEntity<UserTokenDTO> signIn(
+    @PostMapping("/signin")
+    public ResponseEntity<ResponseDTO<UserTokenDTO>> signIn(
             @NotBlank @RequestHeader(AuthConstant.AUTHORIZATION_HEADER) final String platformToken,
             @Valid @RequestBody final UserLoginDTO userLoginDTO
     ) {
-        return ResponseEntity.ok(signInUseCase.signIn(platformToken, userLoginDTO));
+        return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(signInUseCase.signIn(platformToken, userLoginDTO)));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<ResponseDTO<JwtTokenDTO>> refreshAccessToken(
+            @NotBlank @RequestHeader(AuthConstant.AUTHORIZATION_HEADER) final String refreshToken
+    ) {
+        return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(refreshUseCase.refreshAccessToken(refreshToken)));
     }
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/user/UserPersistenceAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/user/UserPersistenceAdapter.java
@@ -1,14 +1,13 @@
 package com.spoony.spoony_server.adapter.out.persistence.user;
 
 import com.spoony.spoony_server.adapter.auth.dto.PlatformUserDTO;
+import com.spoony.spoony_server.adapter.auth.dto.request.UserLoginDTO;
 import com.spoony.spoony_server.adapter.out.persistence.post.db.FollowRepository;
-import com.spoony.spoony_server.adapter.out.persistence.user.db.FollowEntity;
-import com.spoony.spoony_server.adapter.out.persistence.user.db.UserRepository;
+import com.spoony.spoony_server.adapter.out.persistence.user.db.*;
 import com.spoony.spoony_server.adapter.out.persistence.user.mapper.FollowMapper;
 import com.spoony.spoony_server.adapter.out.persistence.user.mapper.UserMapper;
 import com.spoony.spoony_server.application.port.out.user.UserPort;
 import com.spoony.spoony_server.domain.user.Follow;
-import com.spoony.spoony_server.domain.user.Platform;
 import com.spoony.spoony_server.domain.user.User;
 import com.spoony.spoony_server.global.exception.BusinessException;
 import com.spoony.spoony_server.global.message.business.UserErrorMessage;
@@ -23,6 +22,7 @@ public class UserPersistenceAdapter implements UserPort {
 
     private final UserRepository userRepository;
     private final FollowRepository followRepository;
+    private final RegionRepository regionRepository;
 
     public User findUserById(Long userId) {
         return userRepository.findById(userId)
@@ -37,8 +37,25 @@ public class UserPersistenceAdapter implements UserPort {
                 .toList();
     }
 
-    public User loadOrCreate(Platform platform, PlatformUserDTO platformUserDTO) {
-        //TODO
-        return null;
+    public User loadOrCreate(PlatformUserDTO platformUserDTO, UserLoginDTO userLoginDTO) {
+        boolean isRegistered = userRepository.existsByPlatformAndPlatformId(userLoginDTO.platform(), platformUserDTO.platformId());
+
+        RegionEntity regionEntity =  regionRepository.findById(userLoginDTO.regionId())
+                .orElseThrow(() -> new BusinessException(UserErrorMessage.REGION_NOT_FOUND));
+
+        if (!isRegistered) {
+            UserEntity userEntity = UserEntity.builder()
+                    .platform(userLoginDTO.platform())
+                    .platformId(platformUserDTO.platformId())
+                    .userName(userLoginDTO.userName())
+                    .userImage(userLoginDTO.userImage())
+                    .region(regionEntity)
+                    .build();
+            userRepository.save(userEntity);
+        }
+
+        return userRepository.findByPlatformAndPlatformId(userLoginDTO.platform(), platformUserDTO.platformId())
+                .map(UserMapper::toDomain)
+                .orElseThrow(() -> new BusinessException(UserErrorMessage.PLATFORM_USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/user/db/RegionRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/user/db/RegionRepository.java
@@ -1,0 +1,6 @@
+package com.spoony.spoony_server.adapter.out.persistence.user.db;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RegionRepository extends JpaRepository<RegionEntity, Long> {
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/user/db/UserRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/user/db/UserRepository.java
@@ -1,8 +1,14 @@
 package com.spoony.spoony_server.adapter.out.persistence.user.db;
 
+import com.spoony.spoony_server.domain.user.Platform;
+import com.spoony.spoony_server.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
+    boolean existsByPlatformAndPlatformId(Platform platform, String platformId);
+    Optional<UserEntity> findByPlatformAndPlatformId(Platform platform, String platformId);
 }

--- a/src/main/java/com/spoony/spoony_server/application/auth/port/in/RefreshUseCase.java
+++ b/src/main/java/com/spoony/spoony_server/application/auth/port/in/RefreshUseCase.java
@@ -1,0 +1,7 @@
+package com.spoony.spoony_server.application.auth.port.in;
+
+import com.spoony.spoony_server.adapter.auth.dto.response.JwtTokenDTO;
+
+public interface RefreshUseCase {
+    JwtTokenDTO refreshAccessToken(String refreshToken);
+}

--- a/src/main/java/com/spoony/spoony_server/application/auth/service/AuthService.java
+++ b/src/main/java/com/spoony/spoony_server/application/auth/service/AuthService.java
@@ -4,11 +4,15 @@ import com.spoony.spoony_server.adapter.auth.dto.PlatformUserDTO;
 import com.spoony.spoony_server.adapter.auth.dto.request.UserLoginDTO;
 import com.spoony.spoony_server.adapter.auth.dto.response.JwtTokenDTO;
 import com.spoony.spoony_server.adapter.auth.dto.response.UserTokenDTO;
+import com.spoony.spoony_server.adapter.out.persistence.user.db.UserEntity;
+import com.spoony.spoony_server.adapter.out.persistence.user.db.UserRepository;
+import com.spoony.spoony_server.adapter.out.persistence.user.mapper.UserMapper;
+import com.spoony.spoony_server.application.auth.port.in.RefreshUseCase;
 import com.spoony.spoony_server.application.auth.port.in.SignInUseCase;
 import com.spoony.spoony_server.application.port.out.user.UserPort;
-import com.spoony.spoony_server.domain.user.Platform;
 import com.spoony.spoony_server.domain.user.User;
 import com.spoony.spoony_server.global.auth.jwt.JwtTokenProvider;
+import com.spoony.spoony_server.global.auth.jwt.JwtTokenValidator;
 import com.spoony.spoony_server.global.exception.AuthException;
 import com.spoony.spoony_server.global.message.auth.AuthErrorMessage;
 import lombok.RequiredArgsConstructor;
@@ -18,20 +22,36 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class AuthService implements SignInUseCase {
+public class AuthService implements
+        SignInUseCase,
+        RefreshUseCase {
 
     private final UserPort userPort;
     private final JwtTokenProvider jwtTokenProvider;
+    private final JwtTokenValidator jwtTokenValidator;
     private final AppleService appleService;
     private final KakaoService kakaoService;
+    private final UserRepository userRepository;
 
     @Override
     public UserTokenDTO signIn(String platformToken, UserLoginDTO userLoginDTO) {
-        PlatformUserDTO platformUserDTO = getPlatformInfo(platformToken, userLoginDTO);
-        User user = userPort.loadOrCreate(userLoginDTO.platform(), platformUserDTO);
-        JwtTokenDTO token = jwtTokenProvider.issueTokens(user.getUserId());
-        saveToken(user.getUserId(), token);
+//        PlatformUserDTO platformUserDTO = getPlatformInfo(platformToken, userLoginDTO);
+//        User user = userPort.loadOrCreate(platformUserDTO, userLoginDTO);
+
+        UserEntity userEntity = userRepository.findById(1L).orElse(null);
+        User user = UserMapper.toDomain(userEntity);
+
+        JwtTokenDTO token = jwtTokenProvider.generateTokenPair(user.getUserId());
         return UserTokenDTO.of(user, token);
+    }
+
+    @Override
+    public JwtTokenDTO refreshAccessToken(String refreshToken) {
+        if (!jwtTokenValidator.validateAccessToken(refreshToken)) {
+            throw new AuthException(AuthErrorMessage.INVALID_REFRESH_TOKEN);
+        }
+        Long userId = jwtTokenProvider.getUserIdFromToken(refreshToken);
+        return jwtTokenProvider.generateTokenPair(userId);
     }
 
     private PlatformUserDTO getPlatformInfo(String platformToken, UserLoginDTO userLoginDto) {
@@ -42,14 +62,5 @@ public class AuthService implements SignInUseCase {
         } else {
             throw new AuthException(AuthErrorMessage.PLATFORM_NOT_FOUND);
         }
-    }
-
-    private User loadOrCreate(Platform platform, PlatformUserDTO platformUserDTO) {
-        //TODO
-        return null;
-    }
-
-    private void saveToken(Long userId, JwtTokenDTO token) {
-        //TODO
     }
 }

--- a/src/main/java/com/spoony/spoony_server/application/port/out/user/UserPort.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/out/user/UserPort.java
@@ -1,6 +1,7 @@
 package com.spoony.spoony_server.application.port.out.user;
 
 import com.spoony.spoony_server.adapter.auth.dto.PlatformUserDTO;
+import com.spoony.spoony_server.adapter.auth.dto.request.UserLoginDTO;
 import com.spoony.spoony_server.domain.user.Follow;
 import com.spoony.spoony_server.domain.user.Platform;
 import com.spoony.spoony_server.domain.user.User;
@@ -10,5 +11,5 @@ import java.util.List;
 public interface UserPort {
     User findUserById(Long userId);
     List<Follow> findFollowersByUserId(Long userId);
-    User loadOrCreate(Platform platform, PlatformUserDTO platformUserDTO);
+    User loadOrCreate(PlatformUserDTO platformUserDTO, UserLoginDTO userLoginDTO);
 }

--- a/src/main/java/com/spoony/spoony_server/domain/user/Platform.java
+++ b/src/main/java/com/spoony/spoony_server/domain/user/Platform.java
@@ -1,6 +1,6 @@
 package com.spoony.spoony_server.domain.user;
 
 public enum Platform {
-    GOOGLE,
+    KAKAO,
     APPLE
 }

--- a/src/main/java/com/spoony/spoony_server/global/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/spoony/spoony_server/global/auth/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,60 @@
+package com.spoony.spoony_server.global.auth.filter;
+
+import com.spoony.spoony_server.global.auth.jwt.JwtTokenProvider;
+import com.spoony.spoony_server.global.auth.jwt.JwtTokenValidator;
+import com.spoony.spoony_server.global.constant.AuthConstant;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtTokenValidator jwtTokenValidator;
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain chain)
+            throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        if (token != null && jwtTokenValidator.validateAccessToken(token)) {
+            Long userId = jwtTokenProvider.getUserIdFromToken(token);
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userId, null, null);
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AuthConstant.AUTHORIZATION_HEADER);
+        if (bearerToken != null && bearerToken.startsWith(AuthConstant.BEARER_TOKEN_PREFIX)) {
+            return bearerToken.substring(AuthConstant.BEARER_TOKEN_PREFIX.length());
+        }
+        return null;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return path.startsWith("/api/v1/auth/signin") || path.startsWith("/api/v1/auth/refresh");
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/global/auth/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/spoony/spoony_server/global/auth/filter/JwtExceptionFilter.java
@@ -1,0 +1,41 @@
+package com.spoony.spoony_server.global.auth.filter;
+
+import com.spoony.spoony_server.global.exception.AuthException;
+import com.spoony.spoony_server.global.message.auth.AuthErrorMessage;
+import com.spoony.spoony_server.global.message.business.BusinessErrorMessage;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain chain
+    ) throws ServletException, IOException {
+        try {
+            chain.doFilter(request, response);
+        } catch (AuthException e) {
+            request.setAttribute("exception", e.getErrorMessage());
+            chain.doFilter(request, response);
+        } catch (JwtException e) {
+            request.setAttribute("exception", AuthErrorMessage.UNKNOWN_TOKEN);
+            chain.doFilter(request, response);
+        } catch (Exception e) {
+            request.setAttribute("exception", BusinessErrorMessage.INTERNAL_SERVER_ERROR);
+            chain.doFilter(request, response);
+        }
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/global/auth/handler/CustomJwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/spoony/spoony_server/global/auth/handler/CustomJwtAuthenticationEntryPoint.java
@@ -1,0 +1,41 @@
+package com.spoony.spoony_server.global.auth.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spoony.spoony_server.global.dto.ResponseDTO;
+import com.spoony.spoony_server.global.message.auth.AuthErrorMessage;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+public class CustomJwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException {
+        setResponse(response);
+    }
+
+    private void setResponse(HttpServletResponse response) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.getWriter().write(
+                objectMapper.writeValueAsString(ResponseDTO.fail(AuthErrorMessage.UNAUTHORIZED))
+        );
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/global/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/spoony/spoony_server/global/auth/jwt/JwtTokenProvider.java
@@ -19,7 +19,7 @@ import java.util.Date;
 @Component
 public class JwtTokenProvider implements InitializingBean {
 
-    private static final String ANONYMOUS_USER = "anonymousUser";
+    private static final String ANONYMOUS_USER = "anonymous";
 
     @Value("${jwt.access_token_expiration_time}")
     private Long accessTokenExpirationTime;
@@ -36,7 +36,7 @@ public class JwtTokenProvider implements InitializingBean {
         this.singingKey = Keys.hmacShaKeyFor(encodedKey.getBytes());
     }
 
-    public JwtTokenDTO issueTokens(Long userId) {
+    public JwtTokenDTO generateTokenPair(Long userId) {
         return JwtTokenDTO.of(
                 generateToken(userId, true),
                 generateToken(userId, false));
@@ -65,7 +65,7 @@ public class JwtTokenProvider implements InitializingBean {
         return new Date(now.getTime() + refreshTokenExpirationTime);
     }
 
-    public Claims getBody(final String token) {
+    public Claims getClaims(final String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(singingKey)
                 .build()
@@ -73,12 +73,12 @@ public class JwtTokenProvider implements InitializingBean {
                 .getBody();
     }
 
-    public Long getUserIdFromJwt(String token) {
-        Claims claims = getBody(token);
+    public Long getUserIdFromToken(String token) {
+        Claims claims = getClaims(token);
         return Long.valueOf(claims.get(AuthConstant.USER_ID).toString());
     }
 
-    public static Object checkPrincipal(final Object principal) {
+    public static Object validatePrincipal(final Object principal) {
         if (ANONYMOUS_USER.equals(principal)) {
             throw new AuthException(AuthErrorMessage.UNAUTHORIZED);
         }

--- a/src/main/java/com/spoony/spoony_server/global/auth/jwt/JwtTokenValidator.java
+++ b/src/main/java/com/spoony/spoony_server/global/auth/jwt/JwtTokenValidator.java
@@ -1,0 +1,32 @@
+package com.spoony.spoony_server.global.auth.jwt;
+
+import com.spoony.spoony_server.global.exception.AuthException;
+import com.spoony.spoony_server.global.message.auth.AuthErrorMessage;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenValidator {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public boolean validateAccessToken(String accessToken) {
+        try {
+            jwtTokenProvider.getClaims(accessToken);
+        } catch (MalformedJwtException ex) {
+            throw new AuthException(AuthErrorMessage.INVALID_TOKEN);
+        } catch (ExpiredJwtException ex) {
+            throw new AuthException(AuthErrorMessage.EXPIRED_TOKEN);
+        } catch (UnsupportedJwtException ex) {
+            throw new AuthException(AuthErrorMessage.UNSUPPORTED_TOKEN);
+        } catch (IllegalArgumentException ex) {
+            throw new AuthException(AuthErrorMessage.EMPTY_TOKEN);
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/global/config/AsyncConfig.java
+++ b/src/main/java/com/spoony/spoony_server/global/config/AsyncConfig.java
@@ -1,4 +1,4 @@
-package com.spoony.spoony_server.config;
+package com.spoony.spoony_server.global.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;

--- a/src/main/java/com/spoony/spoony_server/global/config/FeignClientConfig.java
+++ b/src/main/java/com/spoony/spoony_server/global/config/FeignClientConfig.java
@@ -1,4 +1,4 @@
-package com.spoony.spoony_server.config;
+package com.spoony.spoony_server.global.config;
 
 import com.spoony.spoony_server.SpoonyServerApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;

--- a/src/main/java/com/spoony/spoony_server/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/spoony/spoony_server/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.spoony.spoony_server.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/spoony/spoony_server/global/config/S3Config.java
+++ b/src/main/java/com/spoony/spoony_server/global/config/S3Config.java
@@ -1,4 +1,4 @@
-package com.spoony.spoony_server.config;
+package com.spoony.spoony_server.global.config;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;

--- a/src/main/java/com/spoony/spoony_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/spoony/spoony_server/global/config/SecurityConfig.java
@@ -1,0 +1,55 @@
+package com.spoony.spoony_server.global.config;
+
+import com.spoony.spoony_server.global.auth.filter.JwtAuthenticationFilter;
+import com.spoony.spoony_server.global.auth.filter.JwtExceptionFilter;
+import com.spoony.spoony_server.global.auth.handler.CustomJwtAuthenticationEntryPoint;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.RequestCacheConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtExceptionFilter jwtExceptionFilter;
+    private final CustomJwtAuthenticationEntryPoint authenticationEntryPoint;
+
+    private static final List<String> AUTH_WHITE_LIST = List.of(
+            "/api/v1/auth/signin",
+            "/api/v1/auth/refresh"
+    );
+
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(cors -> cors.configure(http))
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .requestCache(RequestCacheConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable);
+
+        http
+                .authorizeHttpRequests(auth -> auth
+                .requestMatchers(AUTH_WHITE_LIST.toArray(new String[0])).permitAll()
+                .anyRequest().authenticated());
+
+        http
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class)
+                .exceptionHandling(exceptionHandling ->
+                        exceptionHandling.authenticationEntryPoint(authenticationEntryPoint)
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/global/message/auth/AuthErrorMessage.java
+++ b/src/main/java/com/spoony/spoony_server/global/message/auth/AuthErrorMessage.java
@@ -6,12 +6,22 @@ import org.springframework.http.HttpStatus;
 public enum AuthErrorMessage implements DefaultErrorMessage {
     PLATFORM_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "유효하지 않은 소셜 플랫폼입니다."),
     UNAUTHORIZED(HttpStatus.INTERNAL_SERVER_ERROR, "인증되지 않은 사용자입니다."),
+
+    // APPLE
     INVALID_APPLE_PUBLIC_KEY(HttpStatus.INTERNAL_SERVER_ERROR, "유효하지 않은 Apple Public Key입니다."),
     INVALID_APPLE_IDENTITY_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "유효하지 않은 Apple Identity Token입니다."),
     EXPIRED_APPLE_IDENTITY_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "만료된 Apple Identity Token입니다."),
     CREATE_PUBLIC_KEY_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "Apple Public Key 생성에 실패하였습니다."),
     APPLE_REVOKE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Apple 회원 탈퇴에 실패하였습니다."),
-    APPLE_TOKEN_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Apple 토큰 요청에 실패하였습니다.");
+    APPLE_TOKEN_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Apple 토큰 요청에 실패하였습니다."),
+
+    //JWT
+    INVALID_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "토큰이 만료되었습니다."),
+    UNSUPPORTED_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "지원하지 않는 토큰 형식입니다."),
+    EMPTY_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "토큰이 비어 있거나 잘못된 요청입니다."),
+    UNKNOWN_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 출처의 토큰입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "유효하지 않은 리프레시 토큰입니다.");
 
     private HttpStatus httpStatus;
     private String message;

--- a/src/main/java/com/spoony/spoony_server/global/message/business/UserErrorMessage.java
+++ b/src/main/java/com/spoony/spoony_server/global/message/business/UserErrorMessage.java
@@ -4,7 +4,8 @@ import org.springframework.http.HttpStatus;
 
 public enum UserErrorMessage implements DefaultErrorMessage {
     USER_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "해당 유저를 찾을 수 없습니다."),
-    REGION_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "해당 유저의 지역 정보를 찾을 수 없습니다");
+    REGION_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "해당 유저의 지역 정보를 찾을 수 없습니다"),
+    PLATFORM_USER_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "해당 플랫폼 유저를 찾을 수 없습니다.");
 
     private HttpStatus httpStatus;
     private String message;


### PR DESCRIPTION
### 📝 Work Description
- 서버에서 자체적으로 발행하고, 관리하는 JWT 관련 로직을 구현하였습니다.
- Filter Chain에서 검증과 예외처리를 모두 수행하도록 구현하였습니다.
- Access Token과 Refresh Token을 사용하는 과정에서, Refresh Token Rotation(RTR) 방법을 적용 중입니다.

### ⚙️ Issue
[//]: # (연관된 이슈 번호)
- closed #104 

### 🔨 Changes
- 이제, 회원 가입 요청과 토큰 재발행 요청 이외의 API 호출은 Authorization Bearer Token이 포함되어야 합니다.

### 🔍 PR Point
- RTR 구현 방법에 대해 함께 고민해보면 좋을 것 같습니다.