### PR TITLE
[FEAT] Token User ID 추출, Path Variable 리팩터링

### DIFF
--- a/src/main/java/com/spoony/spoony_server/adapter/in/web/feed/FeedController.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/in/web/feed/FeedController.java
@@ -2,6 +2,7 @@ package com.spoony.spoony_server.adapter.in.web.feed;
 
 import com.spoony.spoony_server.application.port.command.feed.FeedGetCommand;
 import com.spoony.spoony_server.application.port.in.feed.FeedGetUseCase;
+import com.spoony.spoony_server.global.auth.annotation.UserId;
 import com.spoony.spoony_server.global.dto.ResponseDTO;
 import com.spoony.spoony_server.adapter.dto.post.FeedListResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -16,8 +17,8 @@ public class FeedController {
 
     private final FeedGetUseCase feedGetUseCase;
 
-    @GetMapping("/{userId}/{categoryId}")
-    public ResponseEntity<ResponseDTO<FeedListResponseDTO>> getFeedListByUserId(@PathVariable long userId,
+    @GetMapping("/{categoryId}")
+    public ResponseEntity<ResponseDTO<FeedListResponseDTO>> getFeedListByUserId(@UserId Long userId,
                                                                                 @PathVariable long categoryId,
                                                                                 @RequestParam(name = "query") String locationQuery,
                                                                                 @RequestParam(name = "sortBy") String sortBy) {

--- a/src/main/java/com/spoony/spoony_server/adapter/in/web/post/PostController.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/in/web/post/PostController.java
@@ -8,6 +8,7 @@ import com.spoony.spoony_server.application.port.in.post.PostCreateUseCase;
 import com.spoony.spoony_server.application.port.in.post.PostGetCategoriesUseCase;
 import com.spoony.spoony_server.application.port.in.post.PostGetUseCase;
 import com.spoony.spoony_server.application.port.in.post.PostScoopPostUseCase;
+import com.spoony.spoony_server.global.auth.annotation.UserId;
 import com.spoony.spoony_server.global.dto.ResponseDTO;
 import com.spoony.spoony_server.adapter.dto.post.CategoryMonoListResponseDTO;
 import com.spoony.spoony_server.adapter.dto.post.PostResponseDTO;
@@ -33,8 +34,8 @@ public class PostController {
     private final PostGetCategoriesUseCase postGetCategoriesUseCase;
     private final PostScoopPostUseCase postScoopPostUseCase;
 
-    @GetMapping("/{userId}/{postId}")
-    public ResponseEntity<ResponseDTO<PostResponseDTO>> getPost(@PathVariable long postId, @PathVariable long userId) {
+    @GetMapping("/{postId}")
+    public ResponseEntity<ResponseDTO<PostResponseDTO>> getPost(@UserId Long userId, @PathVariable long postId) {
         PostGetCommand command = new PostGetCommand(postId, userId);
         PostResponseDTO postResponse = postGetUseCase.getPostById(command);
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(postResponse));

--- a/src/main/java/com/spoony/spoony_server/adapter/in/web/spoon/SpoonController.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/in/web/spoon/SpoonController.java
@@ -2,6 +2,7 @@ package com.spoony.spoony_server.adapter.in.web.spoon;
 
 import com.spoony.spoony_server.application.port.command.spoon.SpoonGetCommand;
 import com.spoony.spoony_server.application.port.in.spoon.SpoonGetUseCase;
+import com.spoony.spoony_server.global.auth.annotation.UserId;
 import com.spoony.spoony_server.global.dto.ResponseDTO;
 import com.spoony.spoony_server.adapter.dto.spoon.SpoonResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -19,8 +20,8 @@ public class SpoonController {
 
     private final SpoonGetUseCase spoonGetUseCase;
 
-    @GetMapping("/{userId}")
-    public ResponseEntity<ResponseDTO<SpoonResponseDTO>> getSpoonBalance(@PathVariable long userId) {
+    @GetMapping
+    public ResponseEntity<ResponseDTO<SpoonResponseDTO>> getSpoonBalance(@UserId Long userId) {
         SpoonGetCommand command = new SpoonGetCommand(userId);
         SpoonResponseDTO spoonResponseDTO = spoonGetUseCase.getAmountById(command);
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(spoonResponseDTO));

--- a/src/main/java/com/spoony/spoony_server/adapter/in/web/user/UserController.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/in/web/user/UserController.java
@@ -2,6 +2,7 @@ package com.spoony.spoony_server.adapter.in.web.user;
 
 import com.spoony.spoony_server.application.port.command.user.UserGetCommand;
 import com.spoony.spoony_server.application.port.in.user.UserGetUseCase;
+import com.spoony.spoony_server.global.auth.annotation.UserId;
 import com.spoony.spoony_server.global.dto.ResponseDTO;
 import com.spoony.spoony_server.adapter.dto.user.UserResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -19,8 +20,8 @@ public class UserController {
 
     private final UserGetUseCase userGetUseCase;
 
-    @GetMapping("/{userId}")
-    public ResponseEntity<ResponseDTO<UserResponseDTO>> getUserInfo(@PathVariable long userId) {
+    @GetMapping
+    public ResponseEntity<ResponseDTO<UserResponseDTO>> getUserInfo(@UserId Long userId) {
         UserGetCommand command = new UserGetCommand(userId);
         UserResponseDTO userResponseDTO = userGetUseCase.getUserInfo(command);
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(userResponseDTO));

--- a/src/main/java/com/spoony/spoony_server/adapter/in/web/zzim/ZzimPostController.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/in/web/zzim/ZzimPostController.java
@@ -4,6 +4,7 @@ import com.spoony.spoony_server.application.port.command.zzim.*;
 import com.spoony.spoony_server.application.port.in.zzim.ZzimAddUseCase;
 import com.spoony.spoony_server.application.port.in.zzim.ZzimGetUseCase;
 import com.spoony.spoony_server.application.port.in.zzim.ZzimDeleteUseCase;
+import com.spoony.spoony_server.global.auth.annotation.UserId;
 import com.spoony.spoony_server.global.dto.ResponseDTO;
 import com.spoony.spoony_server.adapter.dto.zzim.ZzimPostAddRequestDTO;
 import com.spoony.spoony_server.adapter.dto.zzim.ZzimCardListResponseDTO;
@@ -32,29 +33,29 @@ public class ZzimPostController {
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(null));
     }
 
-    @GetMapping("/{userId}")
-    public ResponseEntity<ResponseDTO<ZzimCardListResponseDTO>> getZzimCardList(@PathVariable long userId) {
+    @GetMapping
+    public ResponseEntity<ResponseDTO<ZzimCardListResponseDTO>> getZzimCardList(@UserId Long userId) {
         ZzimGetCardCommand command = new ZzimGetCardCommand(userId);
         ZzimCardListResponseDTO zzimCardListResponse = zzimGetUseCase.getZzimCardList(command);
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(zzimCardListResponse));
     }
 
-    @GetMapping("/{userId}/{placeId}")
-    public ResponseEntity<ResponseDTO<ZzimFocusListResponseDTO>> getZzimFocusList(@PathVariable long userId, @PathVariable long placeId) {
+    @GetMapping("/{placeId}")
+    public ResponseEntity<ResponseDTO<ZzimFocusListResponseDTO>> getZzimFocusList(@UserId Long userId, @PathVariable long placeId) {
         ZzimGetFocusCommand command = new ZzimGetFocusCommand(userId, placeId);
         ZzimFocusListResponseDTO zzimFocusListResponse = zzimGetUseCase.getZzimFocusList(command);
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(zzimFocusListResponse));
     }
 
-    @GetMapping("/location/{userId}/{locationId}")
-    public ResponseEntity<ResponseDTO<ZzimCardListResponseDTO>> getZzimLocationCardList(@PathVariable long userId, @PathVariable long locationId) {
+    @GetMapping("/location/{locationId}")
+    public ResponseEntity<ResponseDTO<ZzimCardListResponseDTO>> getZzimLocationCardList(@UserId Long userId, @PathVariable long locationId) {
         ZzimGetLocationCardCommand command = new ZzimGetLocationCardCommand(userId, locationId);
         ZzimCardListResponseDTO zzimCardListResponse = zzimGetUseCase.getZzimByLocation(command);
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(zzimCardListResponse));
     }
 
-    @DeleteMapping("/{userId}/{postId}")
-    public ResponseEntity<ResponseDTO<Void>> deleteZzim(@PathVariable long userId, @PathVariable long postId) {
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<ResponseDTO<Void>> deleteZzim(@UserId Long userId, @PathVariable long postId) {
         ZzimDeleteCommand command = new ZzimDeleteCommand(userId, postId);
         zzimRemoveUseCase.deleteZzim(command);
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(null));

--- a/src/main/java/com/spoony/spoony_server/global/auth/annotation/UserId.java
+++ b/src/main/java/com/spoony/spoony_server/global/auth/annotation/UserId.java
@@ -1,0 +1,14 @@
+package com.spoony.spoony_server.global.auth.annotation;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression="T(com.spoony.spoony_server.global.auth.jwt.JwtTokenProvider).validatePrincipal(#this)")
+public @interface UserId {
+}


### PR DESCRIPTION
### 📝 Work Description
- `@UserId` 어노테이션을 선언하여, 사용자 인증 정보로부터 `userId`를 쉽게 가져올 수 있도록 하였습니다.
- 기존에 `@PathVariable` 형태로 가져오던 `userId` 정보를 `@UserId` 어노테이션으로 변경하였습니다.

### ⚙️ Issue
[//]: # (연관된 이슈 번호)
- closed #106 

### 🔨 Changes
- 사용자 정보가 필요한 모든 API 호출에서, `userId` 파라미터가 사라졌고, 대신 `@UserId` 어노테이션 형태로 사용자 ID 정보를 가져올 수 있게 되었습니다.