### PR TITLE
[FEAT] Refresh Token 검증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/in/web/AuthController.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/in/web/AuthController.java
@@ -14,6 +14,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import static com.spoony.spoony_server.global.constant.AuthConstant.BEARER_TOKEN_PREFIX;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
@@ -32,8 +34,12 @@ public class AuthController {
 
     @PostMapping("/refresh")
     public ResponseEntity<ResponseDTO<JwtTokenDTO>> refreshAccessToken(
-            @NotBlank @RequestHeader(AuthConstant.AUTHORIZATION_HEADER) final String refreshToken
+            @NotBlank @RequestHeader(AuthConstant.AUTHORIZATION_HEADER) String refreshToken
     ) {
+        System.out.println("초기 요청 토큰 " + refreshToken);
+        if (refreshToken.startsWith(BEARER_TOKEN_PREFIX)) {
+            refreshToken = refreshToken.substring(BEARER_TOKEN_PREFIX.length());
+        }
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(refreshUseCase.refreshAccessToken(refreshToken)));
     }
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/out/persistence/TokenSearchAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/out/persistence/TokenSearchAdapter.java
@@ -1,0 +1,61 @@
+package com.spoony.spoony_server.adapter.auth.out.persistence;
+
+import com.spoony.spoony_server.adapter.auth.dto.response.JwtTokenDTO;
+import com.spoony.spoony_server.adapter.out.persistence.user.db.TokenEntity;
+import com.spoony.spoony_server.adapter.out.persistence.user.db.TokenRepository;
+import com.spoony.spoony_server.application.auth.port.out.TokenPort;
+import com.spoony.spoony_server.global.annotation.Adapter;
+import com.spoony.spoony_server.global.exception.AuthException;
+import com.spoony.spoony_server.global.message.auth.AuthErrorMessage;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Objects;
+import java.util.Optional;
+
+@Adapter
+@RequiredArgsConstructor
+public class TokenSearchAdapter implements TokenPort {
+
+    private final TokenRepository tokenRepository;
+
+    public void saveToken(Long userId, JwtTokenDTO token) {
+        System.out.println("저장된 refresh token: " + token.refreshToken());
+        TokenEntity tokenEntity = TokenEntity.builder()
+                .id(userId)
+                .refreshToken(token.refreshToken())
+                .build();
+        tokenRepository.save(tokenEntity);
+    }
+
+    public void validateRefreshToken(Long userId, String refreshToken) {
+//        System.out.println("현재 refresh token: " + refreshToken);
+
+        Iterable<TokenEntity> allTokens = tokenRepository.findAll();
+
+//        System.out.println("현재 token repository에 있는 모든 값:");
+//        for (TokenEntity token : allTokens) {
+//            System.out.println("Token : " + token.getRefreshToken());
+//        }
+
+        Optional<TokenEntity> tokenEntityOpt = tokenRepository.findByRefreshToken(refreshToken);
+
+//        System.out.println("DB에서 조회된 TokenEntity: " + tokenEntityOpt.orElse(null));
+
+        // Refresh Token 만료 & 탈취 시나리오 동시 처리
+        if (tokenEntityOpt.isEmpty()) {
+            tokenRepository.deleteById(userId);
+            throw new AuthException(AuthErrorMessage.UNAUTHORIZED);
+        }
+
+        TokenEntity tokenEntity = tokenEntityOpt.get();
+
+        if (!Objects.equals(userId, tokenEntity.getId())) {
+            tokenRepository.deleteById(userId);
+            throw new AuthException(AuthErrorMessage.INVALID_REFRESH_TOKEN);
+        }
+    }
+
+    public void deleteRefreshToken(String refreshToken) {
+        tokenRepository.deleteByRefreshToken(refreshToken);
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/feed/FeedPersistenceAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/feed/FeedPersistenceAdapter.java
@@ -11,6 +11,7 @@ import com.spoony.spoony_server.application.port.out.feed.FeedPort;
 import com.spoony.spoony_server.domain.feed.Feed;
 import com.spoony.spoony_server.domain.post.Post;
 import com.spoony.spoony_server.domain.user.Follow;
+import com.spoony.spoony_server.global.annotation.Adapter;
 import com.spoony.spoony_server.global.exception.BusinessException;
 import com.spoony.spoony_server.global.message.business.PostErrorMessage;
 import com.spoony.spoony_server.global.message.business.UserErrorMessage;
@@ -19,7 +20,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-@Repository
+@Adapter
 @RequiredArgsConstructor
 public class FeedPersistenceAdapter implements FeedPort {
 

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/location/LocationPersistenceAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/location/LocationPersistenceAdapter.java
@@ -5,6 +5,7 @@ import com.spoony.spoony_server.adapter.out.persistence.location.db.LocationRepo
 import com.spoony.spoony_server.adapter.out.persistence.location.mapper.LocationMapper;
 import com.spoony.spoony_server.application.port.out.location.LocationPort;
 import com.spoony.spoony_server.domain.location.Location;
+import com.spoony.spoony_server.global.annotation.Adapter;
 import com.spoony.spoony_server.global.exception.BusinessException;
 import com.spoony.spoony_server.global.message.business.UserErrorMessage;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +14,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Repository
+@Adapter
 @RequiredArgsConstructor
 public class LocationPersistenceAdapter implements LocationPort {
 

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/place/PlacePersistenceAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/place/PlacePersistenceAdapter.java
@@ -5,6 +5,7 @@ import com.spoony.spoony_server.adapter.out.persistence.place.db.PlaceRepository
 import com.spoony.spoony_server.adapter.out.persistence.place.mapper.PlaceMapper;
 import com.spoony.spoony_server.application.port.out.place.PlacePort;
 import com.spoony.spoony_server.domain.place.Place;
+import com.spoony.spoony_server.global.annotation.Adapter;
 import com.spoony.spoony_server.global.exception.BusinessException;
 import com.spoony.spoony_server.global.message.business.PlaceErrorMessage;
 import lombok.RequiredArgsConstructor;
@@ -12,7 +13,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-@Repository
+@Adapter
 @RequiredArgsConstructor
 public class PlacePersistenceAdapter implements PlacePort {
 

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/PostPersistenceAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/PostPersistenceAdapter.java
@@ -13,6 +13,7 @@ import com.spoony.spoony_server.application.port.out.post.PostCategoryPort;
 import com.spoony.spoony_server.application.port.out.post.PostPort;
 import com.spoony.spoony_server.domain.post.*;
 import com.spoony.spoony_server.domain.user.User;
+import com.spoony.spoony_server.global.annotation.Adapter;
 import com.spoony.spoony_server.global.exception.BusinessException;
 import com.spoony.spoony_server.global.message.business.CategoryErrorMessage;
 import com.spoony.spoony_server.global.message.business.PlaceErrorMessage;
@@ -24,7 +25,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Repository
+@Adapter
 @RequiredArgsConstructor
 public class PostPersistenceAdapter implements
         PostPort,

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/report/ReportPersistenceAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/report/ReportPersistenceAdapter.java
@@ -7,13 +7,14 @@ import com.spoony.spoony_server.adapter.out.persistence.user.db.UserEntity;
 import com.spoony.spoony_server.adapter.out.persistence.user.db.UserRepository;
 import com.spoony.spoony_server.application.port.out.report.ReportPort;
 import com.spoony.spoony_server.domain.report.Report;
+import com.spoony.spoony_server.global.annotation.Adapter;
 import com.spoony.spoony_server.global.exception.BusinessException;
 import com.spoony.spoony_server.global.message.business.PostErrorMessage;
 import com.spoony.spoony_server.global.message.business.UserErrorMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-@Repository
+@Adapter
 @RequiredArgsConstructor
 public class ReportPersistenceAdapter implements ReportPort {
 

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/spoon/SpoonPersistenceAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/spoon/SpoonPersistenceAdapter.java
@@ -10,6 +10,7 @@ import com.spoony.spoony_server.application.port.out.spoon.SpoonPort;
 import com.spoony.spoony_server.domain.spoon.Activity;
 import com.spoony.spoony_server.domain.spoon.SpoonBalance;
 import com.spoony.spoony_server.domain.user.User;
+import com.spoony.spoony_server.global.annotation.Adapter;
 import com.spoony.spoony_server.global.exception.BusinessException;
 import com.spoony.spoony_server.global.message.business.SpoonErrorMessage;
 import com.spoony.spoony_server.global.message.business.UserErrorMessage;
@@ -18,7 +19,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 
-@Repository
+@Adapter
 @RequiredArgsConstructor
 public class SpoonPersistenceAdapter implements SpoonPort, SpoonBalancePort {
 

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/user/db/TokenEntity.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/user/db/TokenEntity.java
@@ -1,0 +1,26 @@
+package com.spoony.spoony_server.adapter.out.persistence.user.db;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@Getter
+@RedisHash(value="token", timeToLive = 60 * 60 * 24 * 14)
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+public class TokenEntity {
+    @Id
+    private Long id;
+
+    @Indexed
+    private String refreshToken;
+
+    @Builder
+    public TokenEntity(Long id, String refreshToken) {
+        this.id = id;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/user/db/TokenRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/user/db/TokenRepository.java
@@ -1,0 +1,10 @@
+package com.spoony.spoony_server.adapter.out.persistence.user.db;
+
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface TokenRepository extends CrudRepository<TokenEntity, Long> {
+    Optional<TokenEntity> findByRefreshToken(String refreshToken);
+    void deleteByRefreshToken(String refreshToken);
+}

--- a/src/main/java/com/spoony/spoony_server/application/auth/port/out/TokenPort.java
+++ b/src/main/java/com/spoony/spoony_server/application/auth/port/out/TokenPort.java
@@ -1,0 +1,9 @@
+package com.spoony.spoony_server.application.auth.port.out;
+
+import com.spoony.spoony_server.adapter.auth.dto.response.JwtTokenDTO;
+
+public interface TokenPort {
+    void saveToken(Long userId, JwtTokenDTO token);
+    void validateRefreshToken(Long userId, String refreshToken);
+    void deleteRefreshToken(String refreshToken);
+}

--- a/src/main/java/com/spoony/spoony_server/global/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/spoony/spoony_server/global/advice/GlobalExceptionHandler.java
@@ -1,7 +1,9 @@
 package com.spoony.spoony_server.global.advice;
 
 import com.spoony.spoony_server.global.dto.ResponseDTO;
+import com.spoony.spoony_server.global.exception.AuthException;
 import com.spoony.spoony_server.global.exception.BusinessException;
+import com.spoony.spoony_server.global.message.auth.AuthErrorMessage;
 import com.spoony.spoony_server.global.message.business.BusinessErrorMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,6 +18,13 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(value = {BusinessException.class})
     public ResponseEntity<ResponseDTO<BusinessErrorMessage>> handleBusinessException(BusinessException e) {
+        return ResponseEntity
+                .status(e.getErrorMessage().getHttpStatus())
+                .body(ResponseDTO.fail(e.getErrorMessage()));
+    }
+
+    @ExceptionHandler(value = {AuthException.class})
+    public ResponseEntity<ResponseDTO<AuthErrorMessage>> handleAuthException(AuthException e) {
         return ResponseEntity
                 .status(e.getErrorMessage().getHttpStatus())
                 .body(ResponseDTO.fail(e.getErrorMessage()));

--- a/src/main/java/com/spoony/spoony_server/global/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/spoony/spoony_server/global/auth/filter/JwtAuthenticationFilter.java
@@ -54,7 +54,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        String path = request.getRequestURI();
-        return path.startsWith("/api/v1/auth/signin") || path.startsWith("/api/v1/auth/refresh");
+        String requestURI = request.getRequestURI();
+        return requestURI.startsWith("/api/v1/auth/signin") || requestURI.startsWith("/api/v1/auth/refresh");
     }
 }

--- a/src/main/java/com/spoony/spoony_server/global/auth/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/spoony/spoony_server/global/auth/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,27 @@
+package com.spoony.spoony_server.global.auth.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException, ServletException {
+        setResponse(response);
+    }
+
+    private void setResponse(HttpServletResponse response) {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/global/auth/jwt/JwtTokenValidator.java
+++ b/src/main/java/com/spoony/spoony_server/global/auth/jwt/JwtTokenValidator.java
@@ -29,4 +29,20 @@ public class JwtTokenValidator {
 
         return true;
     }
+
+    public boolean validateRefreshToken(String refreshToken) {
+        try {
+            jwtTokenProvider.getClaims(refreshToken);
+        } catch (MalformedJwtException ex) {
+            throw new AuthException(AuthErrorMessage.INVALID_REFRESH_TOKEN);
+        } catch (ExpiredJwtException ex) {
+            throw new AuthException(AuthErrorMessage.EXPIRED_REFRESH_TOKEN);
+        } catch (UnsupportedJwtException ex) {
+            throw new AuthException(AuthErrorMessage.UNSUPPORTED_REFRESH_TOKEN);
+        } catch (IllegalArgumentException ex) {
+            throw new AuthException(AuthErrorMessage.EMPTY_REFRESH_TOKEN);
+        }
+
+        return true;
+    }
 }

--- a/src/main/java/com/spoony/spoony_server/global/config/RedisConfig.java
+++ b/src/main/java/com/spoony/spoony_server/global/config/RedisConfig.java
@@ -1,0 +1,9 @@
+package com.spoony.spoony_server.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+}

--- a/src/main/java/com/spoony/spoony_server/global/constant/AuthConstant.java
+++ b/src/main/java/com/spoony/spoony_server/global/constant/AuthConstant.java
@@ -8,12 +8,8 @@ public class AuthConstant {
     public static final String USER_ID = "userId";
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String BEARER_TOKEN_PREFIX = "Bearer ";
-    public static final String CHARACTER_ENCODING_UTF8 = "utf-8";
 
     // KAKAO
     public static final String GRANT_TYPE = "KakaoAK ";
     public static final String TARGET_ID_TYPE = "user_id";
-
-    // APPLE
-    public static final String APPLE_WITHDRAW_HEADER = "X-Apple-Code";
 }

--- a/src/main/java/com/spoony/spoony_server/global/exception/AuthException.java
+++ b/src/main/java/com/spoony/spoony_server/global/exception/AuthException.java
@@ -1,15 +1,11 @@
 package com.spoony.spoony_server.global.exception;
 
 import com.spoony.spoony_server.global.message.business.DefaultErrorMessage;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
+@Getter
+@RequiredArgsConstructor
 public class AuthException extends RuntimeException {
     private final DefaultErrorMessage errorMessage;
-
-    public AuthException(DefaultErrorMessage errorMessage) {
-        this.errorMessage = errorMessage;
-    }
-
-    public DefaultErrorMessage getErrorMessage() {
-        return errorMessage;
-    }
 }

--- a/src/main/java/com/spoony/spoony_server/global/exception/BusinessException.java
+++ b/src/main/java/com/spoony/spoony_server/global/exception/BusinessException.java
@@ -1,15 +1,11 @@
 package com.spoony.spoony_server.global.exception;
 
 import com.spoony.spoony_server.global.message.business.DefaultErrorMessage;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
+@Getter
+@RequiredArgsConstructor
 public class BusinessException extends RuntimeException {
     private final DefaultErrorMessage errorMessage;
-
-    public BusinessException(DefaultErrorMessage errorMessage) {
-        this.errorMessage = errorMessage;
-    }
-
-    public DefaultErrorMessage getErrorMessage() {
-        return errorMessage;
-    }
 }

--- a/src/main/java/com/spoony/spoony_server/global/message/auth/AuthErrorMessage.java
+++ b/src/main/java/com/spoony/spoony_server/global/message/auth/AuthErrorMessage.java
@@ -1,11 +1,15 @@
 package com.spoony.spoony_server.global.message.auth;
 
 import com.spoony.spoony_server.global.message.business.DefaultErrorMessage;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
+@Getter
+@RequiredArgsConstructor
 public enum AuthErrorMessage implements DefaultErrorMessage {
     PLATFORM_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "유효하지 않은 소셜 플랫폼입니다."),
-    UNAUTHORIZED(HttpStatus.INTERNAL_SERVER_ERROR, "인증되지 않은 사용자입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
 
     // APPLE
     INVALID_APPLE_PUBLIC_KEY(HttpStatus.INTERNAL_SERVER_ERROR, "유효하지 않은 Apple Public Key입니다."),
@@ -15,27 +19,20 @@ public enum AuthErrorMessage implements DefaultErrorMessage {
     APPLE_REVOKE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Apple 회원 탈퇴에 실패하였습니다."),
     APPLE_TOKEN_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Apple 토큰 요청에 실패하였습니다."),
 
-    //JWT
+    // JWT (ACCESS)
     INVALID_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "토큰이 만료되었습니다."),
     UNSUPPORTED_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "지원하지 않는 토큰 형식입니다."),
     EMPTY_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "토큰이 비어 있거나 잘못된 요청입니다."),
     UNKNOWN_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 출처의 토큰입니다."),
-    INVALID_REFRESH_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "유효하지 않은 리프레시 토큰입니다.");
 
-    private HttpStatus httpStatus;
-    private String message;
+    // JWT (REFRESH)
+    INVALID_REFRESH_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "유효하지 않은 Refresh 토큰입니다."),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "Refresh 토큰이 만료되었습니다."),
+    UNSUPPORTED_REFRESH_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "지원하지 않는 Refresh 토큰 형식입니다."),
+    EMPTY_REFRESH_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "Refresh 토큰이 비어 있거나 잘못된 요청입니다."),
+    UNKNOWN_REFRESH_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 출처의 Refresh 토큰입니다.");
 
-    AuthErrorMessage(HttpStatus httpStatus, String message) {
-        this.httpStatus = httpStatus;
-        this.message = message;
-    }
-
-    public HttpStatus getHttpStatus() {
-        return httpStatus;
-    }
-
-    public String getMessage() {
-        return message;
-    }
+    private final HttpStatus httpStatus;
+    private final String message;
 }

--- a/src/main/java/com/spoony/spoony_server/global/message/business/BusinessErrorMessage.java
+++ b/src/main/java/com/spoony/spoony_server/global/message/business/BusinessErrorMessage.java
@@ -1,26 +1,17 @@
 package com.spoony.spoony_server.global.message.business;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
+@Getter
+@RequiredArgsConstructor
 public enum BusinessErrorMessage implements DefaultErrorMessage {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     MISSING_REQUIRED_HEADER(HttpStatus.BAD_REQUEST, "필수 헤더가 누락되었습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
     NOT_FOUND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "존재하지 않는 데이터입니다.");
 
-    private HttpStatus httpStatus;
-    private String message;
-
-    BusinessErrorMessage(HttpStatus httpStatus, String message) {
-        this.httpStatus = httpStatus;
-        this.message = message;
-    }
-
-    public HttpStatus getHttpStatus() {
-        return httpStatus;
-    }
-
-    public String getMessage() {
-        return message;
-    }
+    private final HttpStatus httpStatus;
+    private final String message;
 }


### PR DESCRIPTION
### 📝 Work Description
- Refresh Token을 통한 검증을 구현하였습니다.
- AccessException을 Advice에 등록하였습니다.
- Refresh Token Rotation(RTR) 방식을 적용하였습니다. 사용자가 잘못된 Refesh Token을 제출할 경우, 현재 유효한 Refresh Token도 무효화되고, 사용자에게 재인증을 요청하게 됩니다.
- Refresh Token의 경우 Redis에 저장하는 방식으로 State를 관리하게 하였습니다.
- `signin`과 `refresh` 요청에 대해서는 Access Token 검증을 진행하지 않도록 Filter를 수정했습니다.

### ⚙️ Issue
[//]: # (연관된 이슈 번호)
- closed #108 

### 🔨 Changes
- Access Token, Refresh Token을 이용하는 JWT 기반 인증이 상당 부분 구현되었습니다.
- Redis 설정이 추가되었고, 사용자의 Refresh Token을 관리하는 Token Repository도 생성되었습니다.

### 🔍 PR Point
- 변경 사항이 많으니, Security Filter -> Jwt Filter -> Token Logic 순서로 검토되면 좋을 것 같습니다.