### PR TITLE
[FEAT] Access & Refresh Token 구분 로직 추가

### DIFF
--- a/src/main/java/com/spoony/spoony_server/adapter/auth/dto/response/UserTokenDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/dto/response/UserTokenDTO.java
@@ -2,12 +2,8 @@ package com.spoony.spoony_server.adapter.auth.dto.response;
 
 import com.spoony.spoony_server.domain.user.User;
 
-public record UserTokenDTO(User user,
-                           JwtTokenDTO jwtTokenDto) {
+public record UserTokenDTO(User user, JwtTokenDTO jwtTokenDto) {
     public static UserTokenDTO of(User user, JwtTokenDTO jwtTokenDTO) {
-        return new UserTokenDTO(
-                user,
-                jwtTokenDTO
-        );
+        return new UserTokenDTO(user, jwtTokenDTO);
     }
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/dto/verification/kakao/KakaoUserDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/dto/verification/kakao/KakaoUserDTO.java
@@ -4,6 +4,5 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record KakaoUserDTO(Long id,
-                           KakaoAccount kakaoAccount) {
+public record KakaoUserDTO(Long id, KakaoAccount kakaoAccount) {
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/in/web/AuthController.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/in/web/AuthController.java
@@ -5,7 +5,7 @@ import com.spoony.spoony_server.adapter.auth.dto.response.JwtTokenDTO;
 import com.spoony.spoony_server.adapter.auth.dto.response.UserTokenDTO;
 import com.spoony.spoony_server.application.auth.port.in.RefreshUseCase;
 import com.spoony.spoony_server.application.auth.port.in.SignInUseCase;
-import com.spoony.spoony_server.global.constant.AuthConstant;
+import com.spoony.spoony_server.global.auth.constant.AuthConstant;
 import com.spoony.spoony_server.global.dto.ResponseDTO;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -14,7 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import static com.spoony.spoony_server.global.constant.AuthConstant.BEARER_TOKEN_PREFIX;
+import static com.spoony.spoony_server.global.auth.constant.AuthConstant.BEARER_TOKEN_PREFIX;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/out/persistence/TokenSearchAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/out/persistence/TokenSearchAdapter.java
@@ -18,6 +18,7 @@ public class TokenSearchAdapter implements TokenPort {
 
     private final TokenRepository tokenRepository;
 
+    @Override
     public void saveToken(Long userId, JwtTokenDTO token) {
         System.out.println("저장된 refresh token: " + token.refreshToken());
         TokenEntity tokenEntity = TokenEntity.builder()
@@ -27,19 +28,9 @@ public class TokenSearchAdapter implements TokenPort {
         tokenRepository.save(tokenEntity);
     }
 
-    public void validateRefreshToken(Long userId, String refreshToken) {
-//        System.out.println("현재 refresh token: " + refreshToken);
-
-        Iterable<TokenEntity> allTokens = tokenRepository.findAll();
-
-//        System.out.println("현재 token repository에 있는 모든 값:");
-//        for (TokenEntity token : allTokens) {
-//            System.out.println("Token : " + token.getRefreshToken());
-//        }
-
+    @Override
+    public void checkRefreshToken(String refreshToken, Long userId, boolean isAccessToken) {
         Optional<TokenEntity> tokenEntityOpt = tokenRepository.findByRefreshToken(refreshToken);
-
-//        System.out.println("DB에서 조회된 TokenEntity: " + tokenEntityOpt.orElse(null));
 
         // Refresh Token 만료 & 탈취 시나리오 동시 처리
         if (tokenEntityOpt.isEmpty()) {
@@ -55,6 +46,7 @@ public class TokenSearchAdapter implements TokenPort {
         }
     }
 
+    @Override
     public void deleteRefreshToken(String refreshToken) {
         tokenRepository.deleteByRefreshToken(refreshToken);
     }

--- a/src/main/java/com/spoony/spoony_server/application/auth/port/out/TokenPort.java
+++ b/src/main/java/com/spoony/spoony_server/application/auth/port/out/TokenPort.java
@@ -4,6 +4,6 @@ import com.spoony.spoony_server.adapter.auth.dto.response.JwtTokenDTO;
 
 public interface TokenPort {
     void saveToken(Long userId, JwtTokenDTO token);
-    void validateRefreshToken(Long userId, String refreshToken);
+    void checkRefreshToken(String refreshToken, Long userId, boolean isAccessToken);
     void deleteRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/spoony/spoony_server/application/auth/service/AuthService.java
+++ b/src/main/java/com/spoony/spoony_server/application/auth/service/AuthService.java
@@ -20,8 +20,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Objects;
-
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -54,8 +52,9 @@ public class AuthService implements
     @Transactional
     public JwtTokenDTO refreshAccessToken(final String refreshToken) {
         jwtTokenValidator.validateRefreshToken(refreshToken);
-        Long userId = jwtTokenProvider.getUserIdFromToken(refreshToken);
-        tokenPort.validateRefreshToken(userId, refreshToken);
+        Long userId = jwtTokenProvider.getClaimFromToken(refreshToken).userId();
+        boolean isAccessToken = jwtTokenProvider.getClaimFromToken(refreshToken).isAccessToken();
+        tokenPort.checkRefreshToken(refreshToken, userId, isAccessToken);
 
         // 현재 refresh token 정보 삭제 (Refresh Token Rotation)
         tokenPort.deleteRefreshToken(refreshToken);

--- a/src/main/java/com/spoony/spoony_server/application/auth/service/KakaoService.java
+++ b/src/main/java/com/spoony/spoony_server/application/auth/service/KakaoService.java
@@ -3,7 +3,7 @@ package com.spoony.spoony_server.application.auth.service;
 import com.spoony.spoony_server.adapter.auth.dto.PlatformUserDTO;
 import com.spoony.spoony_server.adapter.auth.dto.verification.kakao.KakaoUserDTO;
 import com.spoony.spoony_server.adapter.auth.out.external.KakaoFeignClient;
-import com.spoony.spoony_server.global.constant.AuthConstant;
+import com.spoony.spoony_server.global.auth.constant.AuthConstant;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/spoony/spoony_server/global/auth/constant/AuthConstant.java
+++ b/src/main/java/com/spoony/spoony_server/global/auth/constant/AuthConstant.java
@@ -1,4 +1,4 @@
-package com.spoony.spoony_server.global.constant;
+package com.spoony.spoony_server.global.auth.constant;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AuthConstant {
     public static final String USER_ID = "userId";
+    public static final String TOKEN_TYPE = "tokenType";
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String BEARER_TOKEN_PREFIX = "Bearer ";
 

--- a/src/main/java/com/spoony/spoony_server/global/auth/dto/ClaimDTO.java
+++ b/src/main/java/com/spoony/spoony_server/global/auth/dto/ClaimDTO.java
@@ -1,0 +1,7 @@
+package com.spoony.spoony_server.global.auth.dto;
+
+public record ClaimDTO(Long userId, boolean isAccessToken) {
+    public static ClaimDTO of(Long userId, boolean isAccessToken) {
+        return new ClaimDTO(userId, isAccessToken);
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/global/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/spoony/spoony_server/global/auth/filter/JwtAuthenticationFilter.java
@@ -2,7 +2,7 @@ package com.spoony.spoony_server.global.auth.filter;
 
 import com.spoony.spoony_server.global.auth.jwt.JwtTokenProvider;
 import com.spoony.spoony_server.global.auth.jwt.JwtTokenValidator;
-import com.spoony.spoony_server.global.constant.AuthConstant;
+import com.spoony.spoony_server.global.auth.constant.AuthConstant;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -32,14 +32,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
 
         String token = resolveToken(request);
+        jwtTokenValidator.validateAccessToken(token);
 
-        if (token != null && jwtTokenValidator.validateAccessToken(token)) {
-            Long userId = jwtTokenProvider.getUserIdFromToken(token);
-            UsernamePasswordAuthenticationToken authentication =
-                    new UsernamePasswordAuthenticationToken(userId, null, null);
-            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-        }
+        Long userId = jwtTokenProvider.getClaimFromToken(token).userId();
+
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(userId, null, null);
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         chain.doFilter(request, response);
     }

--- a/src/main/java/com/spoony/spoony_server/global/auth/handler/CustomJwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/spoony/spoony_server/global/auth/handler/CustomJwtAuthenticationEntryPoint.java
@@ -27,15 +27,20 @@ public class CustomJwtAuthenticationEntryPoint implements AuthenticationEntryPoi
             HttpServletResponse response,
             AuthenticationException authException
     ) throws IOException {
-        setResponse(response);
+        Object exceptionMessage = request.getAttribute("exception");
+        if (exceptionMessage instanceof AuthErrorMessage authError) {
+            setResponse(response, authError);
+        } else {
+            setResponse(response, AuthErrorMessage.UNAUTHORIZED);
+        }
     }
 
-    private void setResponse(HttpServletResponse response) throws IOException {
+    private void setResponse(HttpServletResponse response, AuthErrorMessage errorMessage) throws IOException {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
         response.getWriter().write(
-                objectMapper.writeValueAsString(ResponseDTO.fail(AuthErrorMessage.UNAUTHORIZED))
+                objectMapper.writeValueAsString(ResponseDTO.fail(errorMessage))
         );
     }
 }

--- a/src/main/java/com/spoony/spoony_server/global/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/spoony/spoony_server/global/auth/jwt/JwtTokenProvider.java
@@ -1,7 +1,8 @@
 package com.spoony.spoony_server.global.auth.jwt;
 
 import com.spoony.spoony_server.adapter.auth.dto.response.JwtTokenDTO;
-import com.spoony.spoony_server.global.constant.AuthConstant;
+import com.spoony.spoony_server.global.auth.constant.AuthConstant;
+import com.spoony.spoony_server.global.auth.dto.ClaimDTO;
 import com.spoony.spoony_server.global.exception.AuthException;
 import com.spoony.spoony_server.global.message.auth.AuthErrorMessage;
 import io.jsonwebtoken.security.SignatureException;
@@ -16,8 +17,6 @@ import io.jsonwebtoken.security.Keys;
 import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
-
-import static com.spoony.spoony_server.global.constant.AuthConstant.BEARER_TOKEN_PREFIX;
 
 @Component
 public class JwtTokenProvider implements InitializingBean {
@@ -54,6 +53,7 @@ public class JwtTokenProvider implements InitializingBean {
                 .setExpiration(expirationDate);
 
         claims.put(AuthConstant.USER_ID, userId);
+        claims.put(AuthConstant.TOKEN_TYPE, isAccessToken);
 
         return Jwts.builder()
                 .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
@@ -81,9 +81,12 @@ public class JwtTokenProvider implements InitializingBean {
         }
     }
 
-    public Long getUserIdFromToken(String token) {
+    public ClaimDTO getClaimFromToken(String token) {
         Claims claims = getClaims(token);
-        return Long.valueOf(claims.get(AuthConstant.USER_ID).toString());
+        return ClaimDTO.of(
+                Long.valueOf(claims.get(AuthConstant.USER_ID).toString()),
+                Boolean.parseBoolean(claims.get(AuthConstant.TOKEN_TYPE).toString())
+        );
     }
 
     public static Object validatePrincipal(final Object principal) {

--- a/src/main/java/com/spoony/spoony_server/global/auth/jwt/JwtTokenValidator.java
+++ b/src/main/java/com/spoony/spoony_server/global/auth/jwt/JwtTokenValidator.java
@@ -14,9 +14,15 @@ public class JwtTokenValidator {
 
     private final JwtTokenProvider jwtTokenProvider;
 
-    public boolean validateAccessToken(String accessToken) {
+    public void validateAccessToken(String accessToken) {
+        if (accessToken == null) {
+            throw new AuthException(AuthErrorMessage.EMPTY_TOKEN);
+        }
         try {
-            jwtTokenProvider.getClaims(accessToken);
+            boolean isAccessToken = jwtTokenProvider.getClaimFromToken(accessToken).isAccessToken();
+            if (!isAccessToken) {
+                throw new AuthException(AuthErrorMessage.INVALID_TOKEN_TYPE);
+            }
         } catch (MalformedJwtException ex) {
             throw new AuthException(AuthErrorMessage.INVALID_TOKEN);
         } catch (ExpiredJwtException ex) {
@@ -26,13 +32,17 @@ public class JwtTokenValidator {
         } catch (IllegalArgumentException ex) {
             throw new AuthException(AuthErrorMessage.EMPTY_TOKEN);
         }
-
-        return true;
     }
 
-    public boolean validateRefreshToken(String refreshToken) {
+    public void validateRefreshToken(String refreshToken) {
+        if (refreshToken == null) {
+            throw new AuthException(AuthErrorMessage.EMPTY_REFRESH_TOKEN);
+        }
         try {
-            jwtTokenProvider.getClaims(refreshToken);
+            boolean isAccessToken = jwtTokenProvider.getClaimFromToken(refreshToken).isAccessToken();
+            if (isAccessToken) {
+                throw new AuthException(AuthErrorMessage.INVALID_TOKEN_TYPE);
+            }
         } catch (MalformedJwtException ex) {
             throw new AuthException(AuthErrorMessage.INVALID_REFRESH_TOKEN);
         } catch (ExpiredJwtException ex) {
@@ -42,7 +52,5 @@ public class JwtTokenValidator {
         } catch (IllegalArgumentException ex) {
             throw new AuthException(AuthErrorMessage.EMPTY_REFRESH_TOKEN);
         }
-
-        return true;
     }
 }

--- a/src/main/java/com/spoony/spoony_server/global/message/auth/AuthErrorMessage.java
+++ b/src/main/java/com/spoony/spoony_server/global/message/auth/AuthErrorMessage.java
@@ -31,7 +31,10 @@ public enum AuthErrorMessage implements DefaultErrorMessage {
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "Refresh 토큰이 만료되었습니다."),
     UNSUPPORTED_REFRESH_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "지원하지 않는 Refresh 토큰 형식입니다."),
     EMPTY_REFRESH_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "Refresh 토큰이 비어 있거나 잘못된 요청입니다."),
-    UNKNOWN_REFRESH_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 출처의 Refresh 토큰입니다.");
+    UNKNOWN_REFRESH_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 출처의 Refresh 토큰입니다."),
+
+    // JWT (ACCESS + REFRESH)
+    INVALID_TOKEN_TYPE(HttpStatus.INTERNAL_SERVER_ERROR, "올바르지 않은 토큰 타입입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
### 📝 Work Description
- Access Token과 Refresh Token를 구분하는 식별자를 서명에 추가했습니다.
- `isAccessToken` 값에 따라 Access Token인지, Refresh Token인지 구분 가능해졌습니다.
- 기본 인증에 Refresh Token을 사용할 경우, 토큰 타입 에러를 반환합니다.
- 토큰 재발급 인증에 Access Token을 사용할 경우에도 토큰 타입 에러를 반환합니다.
- Filter Chain에서, 각 Filter의 Exception의 종류가 무시되는 문제를 수정하였습니다. (`authenticationEntryPoint`가 저장된 예외를 반환하는 방식으로 동작하도록 수정하였습니다.)

### ⚙️ Issue
[//]: # (연관된 이슈 번호)
- closed #110 

### 🔨 Changes
- Work Description에 언급된 파일 위주로 수정되었습니다.