### PR TITLE
[REFACTOR]Zzim리스트 조회 시,  User,Place,Photo,PostCategory 관련 N+1 문제 해결

### DIFF
--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/CategoryEntity.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/CategoryEntity.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "category")
+
 public class CategoryEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PhotoEntity.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PhotoEntity.java
@@ -5,11 +5,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "photo")
+@BatchSize(size = 10)
 public class PhotoEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PhotoRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PhotoRepository.java
@@ -1,10 +1,17 @@
 package com.spoony.spoony_server.adapter.out.persistence.post.db;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface PhotoRepository extends JpaRepository<PhotoEntity, Long> {
     Optional<List<PhotoEntity>> findByPost_PostId(Long postId);
+
+    @Query("SELECT p FROM PhotoEntity p WHERE p.post.postId IN :postIds GROUP BY p.post.postId")
+    List<PhotoEntity> findFirstPhotosByPostIds(@Param("postIds") List<Long> postIds);
+
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostCategoryEntity.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostCategoryEntity.java
@@ -5,11 +5,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "post_category")
+@BatchSize(size = 10)
 public class PostCategoryEntity {
 
     @Id
@@ -31,4 +33,5 @@ public class PostCategoryEntity {
         this.post = post;
         this.category = category;
     }
+
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostCategoryRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostCategoryRepository.java
@@ -1,12 +1,18 @@
 package com.spoony.spoony_server.adapter.out.persistence.post.db;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface PostCategoryRepository extends JpaRepository<PostCategoryEntity, Long> {
     Optional<PostCategoryEntity> findByPost_PostId(Long postID);
+
+    @Query("SELECT pc FROM PostCategoryEntity pc WHERE pc.post.postId IN :postIds")
+    List<PostCategoryEntity> findPostCategoriesByPostIds(@Param("postIds") List<Long> postIds);
 }
 

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostEntity.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostEntity.java
@@ -7,11 +7,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Getter
@@ -40,6 +42,8 @@ public class PostEntity {
     private LocalDateTime createdAt;
     @LastModifiedDate
     private LocalDateTime updatedAt;
+
+
 
     @Builder
     public PostEntity(Long postId, UserEntity user, PlaceEntity place, String title, String description) {

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostRepository.java
@@ -1,11 +1,21 @@
 package com.spoony.spoony_server.adapter.out.persistence.post.db;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<PostEntity, Long> {
+
     List<PostEntity> findByUser_UserId(Long userId);
+
+    @EntityGraph(attributePaths = {"photos", "postCategories", "postCategories.category"})
+    @Query("SELECT p FROM PostEntity p WHERE p.postId = :postId")
+    Optional<PostEntity> findPostWithPhotosAndCategories(@Param("postId") Long postId);
+
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/zzim/db/ZzimPostEntity.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/zzim/db/ZzimPostEntity.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 @Entity
 @Getter

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/zzim/db/ZzimPostRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/zzim/db/ZzimPostRepository.java
@@ -13,6 +13,8 @@ import java.util.List;
 public interface ZzimPostRepository extends JpaRepository<ZzimPostEntity, Long> {
     Long countByPost_PostId(Long postId);
     boolean existsByUser_UserIdAndPost_PostId(Long userId, Long postId);
+
+
     List<ZzimPostEntity> findByUser_UserId(Long userId);
     void deleteByUser_UserIdAndPost_PostId(Long userId, Long postId);
 }

--- a/src/main/java/com/spoony/spoony_server/application/port/out/post/PostPort.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/out/post/PostPort.java
@@ -7,9 +7,11 @@ import com.spoony.spoony_server.domain.post.PostCategory;
 import com.spoony.spoony_server.domain.user.User;
 
 import java.util.List;
+import java.util.Map;
 
 public interface PostPort {
     List<Post> findUserByUserId(Long userId);
+    Post findPostWithPhotosAndCategoriesByPostId(Long postId);
     boolean existsByUserIdAndPostId(Long userId, Long postId);
     Post findPostById(Long postId);
     List<Photo> findPhotoById(Long postId);
@@ -19,4 +21,5 @@ public interface PostPort {
     void saveMenu(Menu menu);
     void savePhoto(Photo photo);
     void saveScoopPost(User user, Post post);
+    Map<Long, PostCategory> findPostCategoriesByPostIds(List<Long> postIds);
 }

--- a/src/main/java/com/spoony/spoony_server/application/port/out/zzim/ZzimPostPort.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/out/zzim/ZzimPostPort.java
@@ -6,6 +6,7 @@ import com.spoony.spoony_server.domain.user.User;
 import com.spoony.spoony_server.domain.zzim.ZzimPost;
 
 import java.util.List;
+import java.util.Map;
 
 public interface ZzimPostPort {
     Long countZzimByPostId(Long postId);
@@ -15,4 +16,5 @@ public interface ZzimPostPort {
     List<ZzimPost> findUserByUserId(Long userId);
     void saveZzimPost(User user, Post post);
     void deleteByUserAndPost(User user, Post post);
+    Map<Long, Photo> findFirstPhotosByPostIds(List<Long> postIds); // 🔥 추가된 메서드
 }

--- a/src/main/java/com/spoony/spoony_server/application/service/post/PostService.java
+++ b/src/main/java/com/spoony/spoony_server/application/service/post/PostService.java
@@ -62,7 +62,9 @@ public class PostService implements
     @Transactional
     public PostResponseDTO getPostById(PostGetCommand command) {
 
-        Post post = postPort.findPostById(command.getPostId());
+        //Post post = postPort.findPostById(command.getPostId());
+        Post post = postPort.findPostWithPhotosAndCategoriesByPostId(command.getPostId());
+
         User user = userPort.findUserById(command.getUserId());
 
         PostCategory postCategory = postCategoryPort.findPostCategoryByPostId(post.getPostId());


### PR DESCRIPTION
### 📝 Work Description
Zzim 리스트 조회 시 발생했던 N+1 문제를 해결하기 위해, User, Place, Photo, PostCategory 조회 방식을 최적화했습니다.
기존에는 개별적으로 쿼리를 실행하여 데이터를 가져왔으나, 전역 Batch Size 설정 + IN 절 조회 방식으로 쿼리를 최적화하여 성능을 개선했습니다.
페이징을 고려하여 Fetch Join 대신 BatchSize 적용을 활용했습니다.

**1. User, Place N+1 문제**
- post:user 관계와 post:place 관계는 n:1 관계이므로, 전역 BatchSize 설정을 통해 N+1 문제를 해결했습니다.
- Hibernate의 hibernate.default_batch_fetch_size를 설정하여, 한 번의 쿼리로 여러 엔티티를 가져오도록 변경했습니다.
- 개별 엔티티에 `@BatchSize`를 추가하여 기본 BatchSize를 사용하지 않는 환경에서도 동일한 효과를 기대할 수 있도록 했습니다.

**2. Photo, PostCategory N+1 문제**
- post:photo와 post:postCategory는 1:n 관계입니다.( 이 경우 전역적으로 batch설정이 안됨) 기존 방식으로는 Post별로 각 Photo나 PostCategory를 개별 쿼리로 조회하여 N+1 문제가 발생했습니다.
- 이를 해결하기 위해, photoRepository와 postCategoryRepository에 새로운 메서드를 추가해, IN 절을 활용한 쿼리로 여러 Post의 Photo 및PostCategory 데이터를 한 번에 가져오도록 수정했습니다.


### ⚙️ Issue
[//]: #112 

### 🔨 Changes

**1. User, Place 조회 방식 변경:**
- 전역 BatchSize 설정(hibernate.default_batch_fetch_size) 적용.

- UserEntity와 PlaceEntity에 `@BatchSize(size = 100)` 추가.


**2. Photo, PostCategory IN 절 조회 적용:**
- 기존에는 개별 Post별로 Photo와 PostCategory를 각각의 쿼리로 조회.

- 새로운 쿼리 메서드를 추가하여 IN 절로 다수의 Post에 대한 Photo와 PostCategory 데이터를 한 번에 가져옴.

- 결과적으로 Photo와 PostCategory 조회에서 발생하던 N+1 문제 해결.

**3. Adapter 및 Port 인터페이스 수정:**
- Zzim 관련 Photo, PostCategory 데이터를 일괄 조회하는 메서드를 추가.
- 서비스 레이어는 포트를 통해 새로운 IN 절 기반 메서드만 사용.


**4. Repository 수정:**
- IN 절 기반 쿼리를 추가하여 한 번의 호출로 필요한 데이터를 모두 가져오도록 변경.

