### PR TITLE
[FEAT] 온보딩(회원가입) 구현

### DIFF
--- a/src/main/java/com/spoony/spoony_server/adapter/auth/dto/request/UserLoginDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/dto/request/UserLoginDTO.java
@@ -3,8 +3,11 @@ package com.spoony.spoony_server.adapter.auth.dto.request;
 import com.spoony.spoony_server.domain.user.Platform;
 import jakarta.validation.constraints.NotNull;
 
+import java.time.LocalDateTime;
+
 public record UserLoginDTO(@NotNull Platform platform,
                            @NotNull String userName,
-                           @NotNull String userImage,
-                           @NotNull Long regionId) {
+                           @NotNull LocalDateTime birth,
+                           @NotNull Long regionId,
+                           @NotNull String introduction) {
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/in/web/user/UserController.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/in/web/user/UserController.java
@@ -1,6 +1,7 @@
 package com.spoony.spoony_server.adapter.in.web.user;
 
 import com.spoony.spoony_server.application.port.command.user.UserGetCommand;
+import com.spoony.spoony_server.application.port.command.user.UserNameCheckCommand;
 import com.spoony.spoony_server.application.port.in.user.UserGetUseCase;
 import com.spoony.spoony_server.global.auth.annotation.UserId;
 import com.spoony.spoony_server.global.dto.ResponseDTO;
@@ -9,10 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,7 +20,7 @@ public class UserController {
     private final UserGetUseCase userGetUseCase;
 
     @GetMapping
-    @Operation(summary = "사용자 정보 조회 API", description = "특정 사용자의 상세 정보를 조회하는 API")
+    @Operation(summary = "사용자 정보 조회 API", description = "특정 사용자의 상세 정보를 조회하는 API (Token 기준)")
     public ResponseEntity<ResponseDTO<UserResponseDTO>> getUserInfo(
             @UserId Long userId) {
         UserGetCommand command = new UserGetCommand(userId);
@@ -31,11 +29,20 @@ public class UserController {
     }
 
     @GetMapping("/{userId}")
-    @Operation(summary = "사용자 정보 조회 API", description = "특정 사용자의 상세 정보를 조회하는 API")
+    @Operation(summary = "사용자 정보 조회 API", description = "특정 사용자의 상세 정보를 조회하는 API (Id 기준)")
     public ResponseEntity<ResponseDTO<UserResponseDTO>> getUserInfoById(
             @PathVariable Long userId) {
         UserGetCommand command = new UserGetCommand(userId);
         UserResponseDTO userResponseDTO = userGetUseCase.getUserInfo(command);
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(userResponseDTO));
+    }
+
+    @GetMapping("/exists")
+    @Operation(summary = "사용자 닉네임 중복 확인 API", description = "사용자의 닉네임이 중복되는지 확인하는 API")
+    public ResponseEntity<ResponseDTO<Boolean>> checkUsernameDuplicate(
+            @RequestParam String userName) {
+        UserNameCheckCommand command = new UserNameCheckCommand(userName);
+        boolean isDuplicate = userGetUseCase.isUsernameDuplicate(command);
+        return ResponseEntity.ok(ResponseDTO.success(isDuplicate));
     }
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostEntity.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostEntity.java
@@ -33,7 +33,7 @@ public class PostEntity {
 
     private String title;
 
-    @Column(columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci")
     private String description;
 
     @CreatedDate

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/mapper/PostMapper.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/mapper/PostMapper.java
@@ -16,8 +16,8 @@ public class PostMapper {
                         postEntity.getUser().getPlatform(),
                         postEntity.getUser().getPlatformId(),
                         postEntity.getUser().getUserName(),
-                        postEntity.getUser().getUserImage(),
                         RegionMapper.toDomain(postEntity.getUser().getRegion()),
+                        postEntity.getUser().getIntroduction(),
                         postEntity.getUser().getCreatedAt(),
                         postEntity.getUser().getUpdatedAt()
                 ),

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/user/UserPersistenceAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/user/UserPersistenceAdapter.java
@@ -30,6 +30,10 @@ public class UserPersistenceAdapter implements UserPort {
                 .orElseThrow(() -> new BusinessException(UserErrorMessage.USER_NOT_FOUND));
     }
 
+    public boolean existsByUserName(String userName) {
+        return userRepository.existsByUserName(userName);
+    }
+
     public List<Follow> findFollowersByUserId(Long userId) {
         List<FollowEntity> followerList = followRepository.findByFollowing_UserId(userId);
         return followerList.stream()
@@ -48,8 +52,8 @@ public class UserPersistenceAdapter implements UserPort {
                     .platform(userLoginDTO.platform())
                     .platformId(platformUserDTO.platformId())
                     .userName(userLoginDTO.userName())
-                    .userImage(userLoginDTO.userImage())
                     .region(regionEntity)
+                    .introduction(userLoginDTO.introduction())
                     .build();
             userRepository.save(userEntity);
         }

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/user/db/UserEntity.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/user/db/UserEntity.java
@@ -27,11 +27,12 @@ public class UserEntity {
     private String platformId;
 
     private String userName;
-    private String userImage;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "region_id")
     private RegionEntity region;
+
+    private String introduction;
 
     @CreatedDate
     private LocalDateTime createdAt;
@@ -43,13 +44,13 @@ public class UserEntity {
                       Platform platform,
                       String platformId,
                       String userName,
-                      String userImage,
-                      RegionEntity region) {
+                      RegionEntity region,
+                      String introduction) {
         this.userId = userId;
         this.platform = platform;
         this.platformId = platformId;
         this.userName = userName;
-        this.userImage = userImage;
         this.region = region;
+        this.introduction = introduction;
     }
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/user/db/UserRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/user/db/UserRepository.java
@@ -11,4 +11,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
     boolean existsByPlatformAndPlatformId(Platform platform, String platformId);
     Optional<UserEntity> findByPlatformAndPlatformId(Platform platform, String platformId);
+    Boolean existsByUserName(String userName);
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/user/mapper/UserMapper.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/user/mapper/UserMapper.java
@@ -12,8 +12,8 @@ public class UserMapper {
                 userEntity.getPlatform(),
                 userEntity.getPlatformId(),
                 userEntity.getUserName(),
-                userEntity.getUserImage(),
                 RegionMapper.toDomain(userEntity.getRegion()),
+                userEntity.getIntroduction(),
                 userEntity.getCreatedAt(),
                 userEntity.getUpdatedAt()
         );

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/zzim/mapper/ZzimMapper.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/zzim/mapper/ZzimMapper.java
@@ -18,8 +18,8 @@ public class ZzimMapper {
                         zzimPostEntity.getUser().getPlatform(),
                         zzimPostEntity.getUser().getPlatformId(),
                         zzimPostEntity.getUser().getUserName(),
-                        zzimPostEntity.getUser().getUserImage(),
                         RegionMapper.toDomain(zzimPostEntity.getUser().getRegion()),
+                        zzimPostEntity.getUser().getIntroduction(),
                         zzimPostEntity.getUser().getCreatedAt(),
                         zzimPostEntity.getUser().getUpdatedAt()
              ),

--- a/src/main/java/com/spoony/spoony_server/application/auth/service/AuthService.java
+++ b/src/main/java/com/spoony/spoony_server/application/auth/service/AuthService.java
@@ -33,16 +33,16 @@ public class AuthService implements
     private final JwtTokenValidator jwtTokenValidator;
     private final AppleService appleService;
     private final KakaoService kakaoService;
-    private final UserRepository userRepository;
 
     @Override
     public UserTokenDTO signIn(String platformToken, UserLoginDTO userLoginDTO) {
-//        PlatformUserDTO platformUserDTO = getPlatformInfo(platformToken, userLoginDTO);
-//        User user = userPort.loadOrCreate(platformUserDTO, userLoginDTO);
 
-        UserEntity userEntity = userRepository.findById(1L).orElse(null);
-        User user = UserMapper.toDomain(userEntity);
+         PlatformUserDTO platformUserDTO = getPlatformInfo(platformToken, userLoginDTO);
 
+//         소셜 로그인 테스트 전, 회원가입 테스트 코드
+//         PlatformUserDTO platformUserDTO = new PlatformUserDTO("test_id", "test_email");
+
+        User user = userPort.loadOrCreate(platformUserDTO, userLoginDTO);
         JwtTokenDTO token = jwtTokenProvider.generateTokenPair(user.getUserId());
         tokenPort.saveToken(user.getUserId(), token);
         return UserTokenDTO.of(user, token);

--- a/src/main/java/com/spoony/spoony_server/application/port/command/user/UserNameCheckCommand.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/command/user/UserNameCheckCommand.java
@@ -1,0 +1,10 @@
+package com.spoony.spoony_server.application.port.command.user;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UserNameCheckCommand {
+    private final String username;
+}

--- a/src/main/java/com/spoony/spoony_server/application/port/in/user/UserGetUseCase.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/in/user/UserGetUseCase.java
@@ -2,7 +2,9 @@ package com.spoony.spoony_server.application.port.in.user;
 
 import com.spoony.spoony_server.adapter.dto.user.UserResponseDTO;
 import com.spoony.spoony_server.application.port.command.user.UserGetCommand;
+import com.spoony.spoony_server.application.port.command.user.UserNameCheckCommand;
 
 public interface UserGetUseCase {
     UserResponseDTO getUserInfo(UserGetCommand command);
+    Boolean isUsernameDuplicate(UserNameCheckCommand command);
 }

--- a/src/main/java/com/spoony/spoony_server/application/port/out/user/UserPort.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/out/user/UserPort.java
@@ -3,13 +3,13 @@ package com.spoony.spoony_server.application.port.out.user;
 import com.spoony.spoony_server.adapter.auth.dto.PlatformUserDTO;
 import com.spoony.spoony_server.adapter.auth.dto.request.UserLoginDTO;
 import com.spoony.spoony_server.domain.user.Follow;
-import com.spoony.spoony_server.domain.user.Platform;
 import com.spoony.spoony_server.domain.user.User;
 
 import java.util.List;
 
 public interface UserPort {
     User findUserById(Long userId);
+    boolean existsByUserName(String userName);
     List<Follow> findFollowersByUserId(Long userId);
     User loadOrCreate(PlatformUserDTO platformUserDTO, UserLoginDTO userLoginDTO);
 }

--- a/src/main/java/com/spoony/spoony_server/application/service/user/UserService.java
+++ b/src/main/java/com/spoony/spoony_server/application/service/user/UserService.java
@@ -1,6 +1,7 @@
 package com.spoony.spoony_server.application.service.user;
 
 import com.spoony.spoony_server.application.port.command.user.UserGetCommand;
+import com.spoony.spoony_server.application.port.command.user.UserNameCheckCommand;
 import com.spoony.spoony_server.application.port.in.user.UserGetUseCase;
 import com.spoony.spoony_server.application.port.out.user.UserPort;
 import com.spoony.spoony_server.domain.user.User;
@@ -22,10 +23,14 @@ public class UserService implements UserGetUseCase {
                 user.getPlatform(),
                 user.getPlatformId(),
                 user.getUserName(),
-                user.getUserImage(),
                 user.getRegion().getRegionName(),
+                user.getIntroduction(),
                 user.getCreatedAt(),
                 user.getUpdatedAt()
         );
+    }
+
+    public Boolean isUsernameDuplicate(UserNameCheckCommand command) {
+        return userPort.existsByUserName(command.getUsername());
     }
 }

--- a/src/main/java/com/spoony/spoony_server/domain/user/User.java
+++ b/src/main/java/com/spoony/spoony_server/domain/user/User.java
@@ -17,8 +17,8 @@ public class User {
 
     private String platformId;
     private String userName;
-    private String userImage;
     private Region region;
+    private String introduction;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/spoony/spoony_server/global/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/spoony/spoony_server/global/auth/filter/JwtAuthenticationFilter.java
@@ -57,6 +57,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String requestURI = request.getRequestURI();
         return requestURI.startsWith("/api/v1/auth/signin")
                 || requestURI.startsWith("/api/v1/auth/refresh")
+                || requestURI.startsWith("/api/v1/user/exists")
                 || requestURI.startsWith("/swagger-ui")
                 || requestURI.startsWith("/v3/api-docs");
     }

--- a/src/main/java/com/spoony/spoony_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/spoony/spoony_server/global/config/SecurityConfig.java
@@ -27,6 +27,7 @@ public class SecurityConfig {
     private static final List<String> AUTH_WHITE_LIST = List.of(
             "/api/v1/auth/signin",
             "/api/v1/auth/refresh",
+            "/api/v1/user/exists",
             "/swagger-ui/**",
             "/v3/api-docs/**"
     );


### PR DESCRIPTION
### 📝 Work Description
- 사용자 회원가입의 전 과정을 구현했습니다
- 변경된 요구사항에 따라 `User` 필드를 수정하였습니다.
- 사용자 닉네임 중복 확인을 위한 별도의 API인 `/api/v1/user/exists`를 구현했습니다.
- 닉네임 중복 확인의 경우, 토큰이 필요하지 않도록 구현하였습니다.

### ⚙️ Issue
[//]: # (연관된 이슈 번호)
- closed #116 

### 🔨 Changes
- `User` 도메인 클래스와 `UserEntity`의 필드가 변경되었습니다.