### PR TITLE
[FEAT] 스푼 뽑기 구현

### DIFF
--- a/src/main/java/com/spoony/spoony_server/adapter/dto/spoon/SpoonDrawListResponseDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/dto/spoon/SpoonDrawListResponseDTO.java
@@ -1,0 +1,8 @@
+package com.spoony.spoony_server.adapter.dto.spoon;
+
+import com.spoony.spoony_server.domain.spoon.SpoonDraw;
+
+import java.util.List;
+
+public record SpoonDrawListResponseDTO(List<SpoonDraw> spoonDrawList) {
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/dto/spoon/SpoonDrawResponseDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/dto/spoon/SpoonDrawResponseDTO.java
@@ -1,0 +1,6 @@
+package com.spoony.spoony_server.adapter.dto.spoon;
+
+import com.spoony.spoony_server.domain.spoon.SpoonDraw;
+
+public record SpoonDrawResponseDTO(SpoonDraw spoonDraw) {
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/in/web/spoon/SpoonController.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/in/web/spoon/SpoonController.java
@@ -1,6 +1,10 @@
 package com.spoony.spoony_server.adapter.in.web.spoon;
 
+import com.spoony.spoony_server.adapter.dto.spoon.SpoonDrawResponseDTO;
+import com.spoony.spoony_server.adapter.dto.spoon.SpoonDrawListResponseDTO;
+import com.spoony.spoony_server.application.port.command.spoon.SpoonDrawCommand;
 import com.spoony.spoony_server.application.port.command.spoon.SpoonGetCommand;
+import com.spoony.spoony_server.application.port.in.spoon.SpoonDrawUseCase;
 import com.spoony.spoony_server.application.port.in.spoon.SpoonGetUseCase;
 import com.spoony.spoony_server.global.auth.annotation.UserId;
 import com.spoony.spoony_server.global.dto.ResponseDTO;
@@ -9,10 +13,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class SpoonController {
 
     private final SpoonGetUseCase spoonGetUseCase;
+    private final SpoonDrawUseCase spoonDrawUseCase;
 
     @GetMapping
     @Operation(summary = "스푼 개수 조회 API", description = "특정 사용자의 스푼 개수를 조회하는 API")
@@ -28,5 +30,23 @@ public class SpoonController {
         SpoonGetCommand command = new SpoonGetCommand(userId);
         SpoonResponseDTO spoonResponseDTO = spoonGetUseCase.getAmountById(command);
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(spoonResponseDTO));
+    }
+
+    @PostMapping("/draw")
+    @Operation(summary = "스푼 뽑기 API", description = "스푼 뽑기를 진행하는 API")
+    public ResponseEntity<ResponseDTO<SpoonDrawResponseDTO>> createSpoonDraw(
+            @UserId Long userId) {
+        SpoonDrawCommand command = new SpoonDrawCommand(userId);
+        SpoonDrawResponseDTO spoonDrawResponseDTO = spoonDrawUseCase.createDrawById(command);
+        return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(spoonDrawResponseDTO));
+    }
+
+    @GetMapping("/draw")
+    @Operation(summary = "스푼 뽑기 기록 조회 API", description = "스푼 뽑기 주간 기록을 조회하는 API")
+    public ResponseEntity<ResponseDTO<SpoonDrawListResponseDTO>> getWeeklySpoonDraw(
+            @UserId Long userId) {
+        SpoonDrawCommand command = new SpoonDrawCommand(userId);
+        SpoonDrawListResponseDTO spoonDrawListResponseDTO = spoonDrawUseCase.getDrawById(command);
+        return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(spoonDrawListResponseDTO));
     }
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/spoon/SpoonPersistenceAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/spoon/SpoonPersistenceAdapter.java
@@ -3,31 +3,45 @@ package com.spoony.spoony_server.adapter.out.persistence.spoon;
 import com.spoony.spoony_server.adapter.out.persistence.spoon.db.*;
 import com.spoony.spoony_server.adapter.out.persistence.spoon.mapper.ActivityMapper;
 import com.spoony.spoony_server.adapter.out.persistence.spoon.mapper.SpoonBalanceMapper;
+import com.spoony.spoony_server.adapter.out.persistence.spoon.mapper.SpoonDrawMapper;
+import com.spoony.spoony_server.adapter.out.persistence.spoon.mapper.SpoonTypeMapper;
 import com.spoony.spoony_server.adapter.out.persistence.user.db.UserEntity;
 import com.spoony.spoony_server.adapter.out.persistence.user.db.UserRepository;
+import com.spoony.spoony_server.application.port.out.spoon.SpoonDrawPort;
 import com.spoony.spoony_server.application.port.out.spoon.SpoonBalancePort;
 import com.spoony.spoony_server.application.port.out.spoon.SpoonPort;
+import com.spoony.spoony_server.application.port.out.spoon.SpoonTypePort;
 import com.spoony.spoony_server.domain.spoon.Activity;
 import com.spoony.spoony_server.domain.spoon.SpoonBalance;
+import com.spoony.spoony_server.domain.spoon.SpoonDraw;
+import com.spoony.spoony_server.domain.spoon.SpoonType;
 import com.spoony.spoony_server.domain.user.User;
 import com.spoony.spoony_server.global.annotation.Adapter;
 import com.spoony.spoony_server.global.exception.BusinessException;
 import com.spoony.spoony_server.global.message.business.SpoonErrorMessage;
 import com.spoony.spoony_server.global.message.business.UserErrorMessage;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Adapter
 @RequiredArgsConstructor
-public class SpoonPersistenceAdapter implements SpoonPort, SpoonBalancePort {
+public class SpoonPersistenceAdapter implements
+        SpoonPort,
+        SpoonBalancePort,
+        SpoonDrawPort,
+        SpoonTypePort {
 
     private final ActivityRepository activityRepository;
     private final SpoonBalanceRepository spoonBalanceRepository;
     private final UserRepository userRepository;
     private final SpoonHistoryRepository spoonHistoryRepository;
+    private final SpoonDrawRepository spoonDrawRepository;
+    private final SpoonTypeRepository spoonTypeRepository;
 
+    @Override
     public Activity findActivityByActivityId(Long activityId) {
         ActivityEntity activityEntity = activityRepository.findById(activityId)
                 .orElseThrow(() -> new BusinessException(SpoonErrorMessage.ACTIVITY_NOT_FOUND));
@@ -43,6 +57,7 @@ public class SpoonPersistenceAdapter implements SpoonPort, SpoonBalancePort {
         spoonBalanceRepository.save(spoonBalanceEntity);
     }
 
+    @Override
     public void updateSpoonHistory(User user, Activity activity) {
         SpoonBalanceEntity spoonBalanceEntity = spoonBalanceRepository.findByUser_UserId(user.getUserId())
                 .orElseThrow(() -> new BusinessException(SpoonErrorMessage.USER_NOT_FOUND));
@@ -65,5 +80,49 @@ public class SpoonPersistenceAdapter implements SpoonPort, SpoonBalancePort {
         return spoonBalanceRepository.findByUser_UserId(userId)
                 .map(SpoonBalanceMapper::toDomain)
                 .orElseThrow(() -> new BusinessException(SpoonErrorMessage.USER_NOT_FOUND));
+    }
+
+    @Override
+    public Boolean existsByUserIdAndDrawDate(Long userId, LocalDate today) {
+        return spoonDrawRepository.existsByUser_UserIdAndDrawDate(userId, today);
+    }
+
+    @Override
+    public List<SpoonType> findAll() {
+        return spoonTypeRepository.findAll().stream()
+                .map(SpoonTypeMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public Long save(Long userId, SpoonType selectedType, LocalDate today, LocalDate weekStart) {
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorMessage.USER_NOT_FOUND));
+
+        SpoonTypeEntity spoonTypeEntity = spoonTypeRepository.findById(selectedType.getSpoonTypeId())
+                .orElseThrow(() -> new BusinessException(SpoonErrorMessage.SPOON_TYPE_NOT_FOUND));
+
+        SpoonDrawEntity spoonDrawEntity = SpoonDrawEntity.builder()
+                .user(userEntity)
+                .spoonType(spoonTypeEntity)
+                .drawDate(today)
+                .weekStartDate(weekStart)
+                .build();
+
+        return spoonDrawRepository.save(spoonDrawEntity).getDrawId();
+    }
+
+    @Override
+    public SpoonDraw findById(Long drawId) {
+        return spoonDrawRepository.findById(drawId)
+                .map(SpoonDrawMapper::toDomain)
+                .orElseThrow(() -> new BusinessException(SpoonErrorMessage.SPOON_DRAW_NOT_FOUND));
+    }
+
+    @Override
+    public List<SpoonDraw> findAllByUserIdAndWeekStartDate(Long userId, LocalDate weekStart) {
+        return spoonDrawRepository.findAllByUser_UserIdAndWeekStartDateOrderByDrawDateAsc(userId, weekStart).stream()
+                .map(SpoonDrawMapper::toDomain)
+                .toList();
     }
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/spoon/db/SpoonDrawEntity.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/spoon/db/SpoonDrawEntity.java
@@ -1,0 +1,47 @@
+package com.spoony.spoony_server.adapter.out.persistence.spoon.db;
+
+import com.spoony.spoony_server.adapter.out.persistence.user.db.UserEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "spoon_draw")
+public class SpoonDrawEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long drawId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "spoon_type_id", nullable = false)
+    private SpoonTypeEntity spoonType;
+
+    @Column(name = "draw_date", nullable = false)
+    private LocalDate drawDate;
+
+    @Column(name = "week_start_date", nullable = false)
+    private LocalDate weekStartDate;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public SpoonDrawEntity(UserEntity user, SpoonTypeEntity spoonType, LocalDate drawDate, LocalDate weekStartDate) {
+        this.user = user;
+        this.spoonType = spoonType;
+        this.drawDate = drawDate;
+        this.weekStartDate = weekStartDate;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/spoon/db/SpoonDrawRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/spoon/db/SpoonDrawRepository.java
@@ -1,0 +1,11 @@
+package com.spoony.spoony_server.adapter.out.persistence.spoon.db;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface SpoonDrawRepository extends JpaRepository<SpoonDrawEntity, Long> {
+    Boolean existsByUser_UserIdAndDrawDate(Long userId, LocalDate drawDate);
+    List<SpoonDrawEntity> findAllByUser_UserIdAndWeekStartDateOrderByDrawDateAsc(Long userId, LocalDate weekStartDate);
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/spoon/db/SpoonTypeEntity.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/spoon/db/SpoonTypeEntity.java
@@ -1,0 +1,30 @@
+package com.spoony.spoony_server.adapter.out.persistence.spoon.db;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "spoon_type")
+public class SpoonTypeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long spoonTypeId;
+
+    @Column(nullable = false, length = 50)
+    private String spoonName;
+
+    @Column(nullable = false)
+    private int spoonAmount;
+
+    @Column(nullable = false, precision = 5, scale = 2)
+    private BigDecimal probability;
+
+    @Column(nullable = false)
+    private String spoonImage;
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/spoon/db/SpoonTypeRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/spoon/db/SpoonTypeRepository.java
@@ -1,0 +1,6 @@
+package com.spoony.spoony_server.adapter.out.persistence.spoon.db;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpoonTypeRepository extends JpaRepository<SpoonTypeEntity, Long> {
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/spoon/mapper/SpoonDrawMapper.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/spoon/mapper/SpoonDrawMapper.java
@@ -1,0 +1,19 @@
+package com.spoony.spoony_server.adapter.out.persistence.spoon.mapper;
+
+import com.spoony.spoony_server.adapter.out.persistence.spoon.db.SpoonDrawEntity;
+import com.spoony.spoony_server.adapter.out.persistence.user.mapper.UserMapper;
+import com.spoony.spoony_server.domain.spoon.SpoonDraw;
+
+public class SpoonDrawMapper {
+
+    public static SpoonDraw toDomain(SpoonDrawEntity spoonDrawEntity) {
+        return new SpoonDraw(
+                spoonDrawEntity.getDrawId(),
+                UserMapper.toDomain(spoonDrawEntity.getUser()),
+                SpoonTypeMapper.toDomain(spoonDrawEntity.getSpoonType()),
+                spoonDrawEntity.getDrawDate(),
+                spoonDrawEntity.getWeekStartDate(),
+                spoonDrawEntity.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/spoon/mapper/SpoonTypeMapper.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/spoon/mapper/SpoonTypeMapper.java
@@ -1,0 +1,17 @@
+package com.spoony.spoony_server.adapter.out.persistence.spoon.mapper;
+
+import com.spoony.spoony_server.adapter.out.persistence.spoon.db.SpoonTypeEntity;
+import com.spoony.spoony_server.domain.spoon.SpoonType;
+
+public class SpoonTypeMapper {
+
+    public static SpoonType toDomain(SpoonTypeEntity spoonTypeEntity) {
+        return new SpoonType(
+                spoonTypeEntity.getSpoonTypeId(),
+                spoonTypeEntity.getSpoonName(),
+                spoonTypeEntity.getSpoonAmount(),
+                spoonTypeEntity.getProbability(),
+                spoonTypeEntity.getSpoonImage()
+        );
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/application/port/command/spoon/SpoonDrawCommand.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/command/spoon/SpoonDrawCommand.java
@@ -1,0 +1,10 @@
+package com.spoony.spoony_server.application.port.command.spoon;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class SpoonDrawCommand {
+    private final Long userId;
+}

--- a/src/main/java/com/spoony/spoony_server/application/port/command/spoon/SpoonDrawWeeklyCommand.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/command/spoon/SpoonDrawWeeklyCommand.java
@@ -1,0 +1,10 @@
+package com.spoony.spoony_server.application.port.command.spoon;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class SpoonDrawWeeklyCommand {
+    private final Long userId;
+}

--- a/src/main/java/com/spoony/spoony_server/application/port/in/spoon/SpoonDrawUseCase.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/in/spoon/SpoonDrawUseCase.java
@@ -1,0 +1,10 @@
+package com.spoony.spoony_server.application.port.in.spoon;
+
+import com.spoony.spoony_server.adapter.dto.spoon.SpoonDrawListResponseDTO;
+import com.spoony.spoony_server.adapter.dto.spoon.SpoonDrawResponseDTO;
+import com.spoony.spoony_server.application.port.command.spoon.SpoonDrawCommand;
+
+public interface SpoonDrawUseCase {
+    SpoonDrawResponseDTO createDrawById(SpoonDrawCommand command);
+    SpoonDrawListResponseDTO getDrawById(SpoonDrawCommand command);
+}

--- a/src/main/java/com/spoony/spoony_server/application/port/out/spoon/SpoonDrawPort.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/out/spoon/SpoonDrawPort.java
@@ -1,0 +1,14 @@
+package com.spoony.spoony_server.application.port.out.spoon;
+
+import com.spoony.spoony_server.domain.spoon.SpoonDraw;
+import com.spoony.spoony_server.domain.spoon.SpoonType;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface SpoonDrawPort {
+    Boolean existsByUserIdAndDrawDate(Long userId, LocalDate today);
+    Long save(Long userId, SpoonType selectedType, LocalDate today, LocalDate weekStart);
+    SpoonDraw findById(Long drawId);
+    List<SpoonDraw> findAllByUserIdAndWeekStartDate(Long userId, LocalDate weekStart);
+}

--- a/src/main/java/com/spoony/spoony_server/application/port/out/spoon/SpoonTypePort.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/out/spoon/SpoonTypePort.java
@@ -1,0 +1,9 @@
+package com.spoony.spoony_server.application.port.out.spoon;
+
+import com.spoony.spoony_server.domain.spoon.SpoonType;
+
+import java.util.List;
+
+public interface SpoonTypePort {
+    List<SpoonType> findAll();
+}

--- a/src/main/java/com/spoony/spoony_server/application/service/spoon/SpoonService.java
+++ b/src/main/java/com/spoony/spoony_server/application/service/spoon/SpoonService.java
@@ -1,24 +1,93 @@
 package com.spoony.spoony_server.application.service.spoon;
 
+import com.spoony.spoony_server.adapter.dto.spoon.SpoonDrawResponseDTO;
+import com.spoony.spoony_server.adapter.dto.spoon.SpoonDrawListResponseDTO;
+import com.spoony.spoony_server.application.port.command.spoon.SpoonDrawCommand;
 import com.spoony.spoony_server.application.port.command.spoon.SpoonGetCommand;
+import com.spoony.spoony_server.application.port.in.spoon.SpoonDrawUseCase;
 import com.spoony.spoony_server.application.port.in.spoon.SpoonGetUseCase;
+import com.spoony.spoony_server.application.port.out.spoon.SpoonDrawPort;
 import com.spoony.spoony_server.application.port.out.spoon.SpoonBalancePort;
+import com.spoony.spoony_server.application.port.out.spoon.SpoonTypePort;
+import com.spoony.spoony_server.application.port.out.user.UserPort;
 import com.spoony.spoony_server.domain.spoon.SpoonBalance;
 import com.spoony.spoony_server.adapter.dto.spoon.SpoonResponseDTO;
 
+import com.spoony.spoony_server.domain.spoon.SpoonDraw;
+import com.spoony.spoony_server.domain.spoon.SpoonType;
+import com.spoony.spoony_server.global.exception.BusinessException;
+import com.spoony.spoony_server.global.message.business.SpoonErrorMessage;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
-public class SpoonService implements SpoonGetUseCase {
+public class SpoonService implements SpoonGetUseCase, SpoonDrawUseCase {
 
     private final SpoonBalancePort spoonBalancePort;
+    private final SpoonDrawPort spoonDrawPort;
+    private final SpoonTypePort spoonTypePort;
 
     @Transactional
     public SpoonResponseDTO getAmountById(SpoonGetCommand command){
         SpoonBalance spoonBalance = spoonBalancePort.findBalanceByUserId(command.getUserId());
         return new SpoonResponseDTO(spoonBalance.getAmount());
+    }
+
+    @Transactional
+    public SpoonDrawResponseDTO createDrawById(SpoonDrawCommand command){
+        LocalDate today = LocalDate.now();
+        LocalDate weekStart = today.with(DayOfWeek.MONDAY);
+        Long userId = command.getUserId();
+
+        // 중복 뽑기 확인
+        boolean alreadyDrawn = spoonDrawPort.existsByUserIdAndDrawDate(userId, today);
+        if (alreadyDrawn) {
+            throw new BusinessException(SpoonErrorMessage.ALREADY_DRAWN);
+        }
+
+        // 모든 스푼 타입 조회
+        List<SpoonType> spoonTypeList = spoonTypePort.findAll();
+        if (spoonTypeList.isEmpty()) {
+            throw new BusinessException(SpoonErrorMessage.SPOON_TYPE_NOT_FOUND);
+        }
+
+        // 스푼 타입 결정
+        double random = Math.random() * 100;
+        double accumulated = 0;
+        SpoonType selectedType = null;
+
+        for (SpoonType type : spoonTypeList) {
+            accumulated += type.getProbability().doubleValue();
+            if (random < accumulated) {
+                selectedType = type;
+                break;
+            }
+        }
+
+        if (selectedType == null) {
+            selectedType = spoonTypeList.getLast();
+        }
+
+        // 스푼 뽑기 결과 저장
+        Long drawId = spoonDrawPort.save(userId, selectedType, today, weekStart);
+        SpoonDraw spoonDraw = spoonDrawPort.findById(drawId);
+
+        return new SpoonDrawResponseDTO(spoonDraw);
+    }
+
+    @Transactional
+    public SpoonDrawListResponseDTO getDrawById(SpoonDrawCommand command) {
+        Long userId = command.getUserId();
+        LocalDate weekStart = LocalDate.now().with(DayOfWeek.MONDAY);
+        List<SpoonDraw> spoonDrawList = spoonDrawPort.findAllByUserIdAndWeekStartDate(userId, weekStart);
+
+        return new SpoonDrawListResponseDTO(spoonDrawList);
     }
 }

--- a/src/main/java/com/spoony/spoony_server/domain/spoon/SpoonDraw.java
+++ b/src/main/java/com/spoony/spoony_server/domain/spoon/SpoonDraw.java
@@ -1,0 +1,21 @@
+package com.spoony.spoony_server.domain.spoon;
+
+import com.spoony.spoony_server.domain.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class SpoonDraw {
+    private Long drawId;
+    private User user;
+    private SpoonType spoonType;
+    private LocalDate drawDate;
+    private LocalDate weekStartDate;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/spoony/spoony_server/domain/spoon/SpoonType.java
+++ b/src/main/java/com/spoony/spoony_server/domain/spoon/SpoonType.java
@@ -1,0 +1,18 @@
+package com.spoony.spoony_server.domain.spoon;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class SpoonType {
+    private Long spoonTypeId;
+    private String spoonName;
+    private int spoonAmount;
+    private BigDecimal probability;
+    private String spoonImage;
+}

--- a/src/main/java/com/spoony/spoony_server/global/message/business/SpoonErrorMessage.java
+++ b/src/main/java/com/spoony/spoony_server/global/message/business/SpoonErrorMessage.java
@@ -5,7 +5,10 @@ import org.springframework.http.HttpStatus;
 public enum SpoonErrorMessage implements DefaultErrorMessage {
     ACTIVITY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 활동 종류입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "스푼 정보가 없는 사용자입니다."),
-    NOT_ENOUGH_SPOONS(HttpStatus.CONFLICT, "스푼 갯수가 부족합니다.");
+    NOT_ENOUGH_SPOONS(HttpStatus.CONFLICT, "스푼 갯수가 부족합니다."),
+    ALREADY_DRAWN(HttpStatus.BAD_REQUEST, "이미 스폰 뽑기를 진행한 사용자입니다."),
+    SPOON_TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "스푼 종류가 비어있습니다."),
+    SPOON_DRAW_NOT_FOUND(HttpStatus.NOT_FOUND, "스푼 뽑기 내역이 없습니다.");
 
     private HttpStatus httpStatus;
     private String message;


### PR DESCRIPTION
### 📝 Work Description
- 기본적인 스푼 뽑기 구현을 완료하였습니다.
- 스푼 뽑기 구현을 위해 스푼 종류를 의미하는 테이블인 `SpoonType`과, 스푼 뽑기 내역을 의미하는 `SpoonDraw` 테이블을 새롭게 생성하였습니다.
- 스푼 뽑기는 하루에 한 번만 진행할 수 있습니다.
- 스푼 종류의 경우 명세서에 명시된 확률을 준수하였습니다.
- 스푼을 뽑는 행위와, 스푼 뽑기 내역을 조회하는 행위로 나누어 두 개의 API를 구현하였습니다.

### ⚙️ Issue
[//]: # (연관된 이슈 번호)
- closed #118 

### 🔨 Changes
- 필요한 테이블이 추가되었습니다.

### 🔍 PR Point
- 현재는 뽑기 기능만 구현되어 있습니다.
- 다음 작업에서 사용자 스푼 개수 변경 로직을 추가로 구현하고, 응답 데이터 리팩터링을 진행할 에정입니다.