### PR TITLE
[FEAT] 게시물 수정, 삭제 구현

### DIFF
--- a/src/main/java/com/spoony/spoony_server/adapter/dto/post/PostCreateRequestDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/dto/post/PostCreateRequestDTO.java
@@ -1,4 +1,4 @@
-package com.spoony.spoony_server.adapter.dto.zzim;
+package com.spoony.spoony_server.adapter.dto.post;
 
 import java.util.List;
 

--- a/src/main/java/com/spoony/spoony_server/adapter/dto/post/PostUpdateRequestDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/dto/post/PostUpdateRequestDTO.java
@@ -1,0 +1,11 @@
+package com.spoony.spoony_server.adapter.dto.post;
+
+import java.util.List;
+
+public record PostUpdateRequestDTO(Long postId,
+                                   String description,
+                                   Double value,
+                                   String cons,
+                                   Long categoryId,
+                                   List<String> menuList) {
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/in/web/post/PostController.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/in/web/post/PostController.java
@@ -122,6 +122,10 @@ public class PostController {
             @Parameter(description = "게시물 수정 사진 리스트 (이미지 파일)")
             List<MultipartFile> photos
     ) throws IOException {
+        // 사진 삭제 후 재업로드
+        PostDeleteCommand deleteCommand = new PostDeleteCommand(postUpdateRequestDTO.postId());
+        postDeleteUseCase.deletePhotos(deleteCommand);
+
         PostPhotoSaveCommand photoSaveCommand = new PostPhotoSaveCommand(photos);
         List<String> photoUrlList = postCreateUseCase.savePostImages(photoSaveCommand);
 

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/PostPersistenceAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/PostPersistenceAdapter.java
@@ -21,6 +21,7 @@ import com.spoony.spoony_server.global.message.business.PostErrorMessage;
 import com.spoony.spoony_server.global.message.business.UserErrorMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -41,7 +42,7 @@ public class PostPersistenceAdapter implements
     private final UserRepository userRepository;
     private final PlaceRepository placeRepository;
 
-    @Override
+    @Transactional
     public List<Post> findUserByUserId(Long userId) {
         return postRepository.findByUser_UserId(userId)
                 .stream()
@@ -49,28 +50,33 @@ public class PostPersistenceAdapter implements
                 .collect(Collectors.toList());
     }
 
+    @Transactional
     public Post findPostById(Long postId) {
         return postRepository.findById(postId)
                 .map(PostMapper::toDomain)
                 .orElseThrow(() -> new BusinessException(PostErrorMessage.POST_NOT_FOUND));
     }
 
+    @Transactional
     public PostCategory findPostCategoryByPostId(Long postId) {
         return postCategoryRepository.findByPost_PostId(postId)
                 .map(PostCategoryMapper::toDomain)
                 .orElseThrow(() -> new BusinessException(CategoryErrorMessage.CATEGORY_NOT_FOUND));
     }
 
+    @Transactional
     public Category findCategoryById(Long categoryId) {
         return categoryRepository.findById(categoryId)
                 .map(CategoryMapper::toDomain)
                 .orElseThrow(() -> new BusinessException(CategoryErrorMessage.CATEGORY_NOT_FOUND));
     }
 
+    @Transactional
     public boolean existsByUserIdAndPostId(Long userId, Long postId) {
         return scoopPostRepository.existsByUser_UserIdAndPost_PostId(userId, postId);
     }
 
+    @Transactional
     public List<Photo> findPhotoById(Long postId) {
         return photoRepository.findByPost_PostId(postId)
                 .orElseThrow(() -> new BusinessException(PostErrorMessage.PHOTO_NOT_FOUND))
@@ -79,6 +85,7 @@ public class PostPersistenceAdapter implements
                 .collect(Collectors.toList());
     }
 
+    @Transactional
     public List<Menu> findMenuById(Long postId) {
         return menuRepository.findByPost_PostId(postId)
                 .orElseThrow(() -> new BusinessException(PostErrorMessage.MENU_NOT_FOUND))
@@ -87,6 +94,7 @@ public class PostPersistenceAdapter implements
                 .collect(Collectors.toList());
     }
 
+    @Transactional
     public Long savePost(Post post) {
         UserEntity userEntity = userRepository.findById(post.getUser().getUserId())
                 .orElseThrow(() -> new BusinessException(UserErrorMessage.USER_NOT_FOUND));
@@ -107,6 +115,7 @@ public class PostPersistenceAdapter implements
         return postEntity.getPostId();
     }
 
+    @Transactional
     public void savePostCategory(PostCategory postCategory) {
         PostEntity postEntity = postRepository.findById(postCategory.getPost().getPostId())
                 .orElseThrow(() -> new BusinessException(PostErrorMessage.POST_NOT_FOUND));
@@ -122,6 +131,7 @@ public class PostPersistenceAdapter implements
         postCategoryRepository.save(postCategoryEntity);
     }
 
+    @Transactional
     public void saveMenu(Menu menu) {
         PostEntity postEntity = postRepository.findById(menu.getPost().getPostId())
                 .orElseThrow(() -> new BusinessException(PostErrorMessage.POST_NOT_FOUND));
@@ -134,6 +144,7 @@ public class PostPersistenceAdapter implements
         menuRepository.save(menuEntity);
     }
 
+    @Transactional
     public void savePhoto(Photo photo) {
         PostEntity postEntity = postRepository.findById(photo.getPost().getPostId())
                 .orElseThrow(() -> new BusinessException(PostErrorMessage.POST_NOT_FOUND));
@@ -146,19 +157,21 @@ public class PostPersistenceAdapter implements
         photoRepository.save(photoEntity);
     }
 
+    @Transactional
     public List<Category> findAllCategories() {
         return categoryRepository.findAll().stream()
                 .map(CategoryMapper::toDomain)
                 .toList();
     }
 
+    @Transactional
     public List<Category> findFoodCategories() {
         return categoryRepository.findByCategoryType(CategoryType.FOOD).stream()
                 .map(CategoryMapper::toDomain)
                 .toList();
     }
 
-
+    @Transactional
     public void saveScoopPost(User user, Post post) {
         UserEntity userEntity = userRepository.findById(user.getUserId())
                 .orElseThrow(() -> new BusinessException(UserErrorMessage.USER_NOT_FOUND));
@@ -172,5 +185,36 @@ public class PostPersistenceAdapter implements
                 .build();
 
         scoopPostRepository.save(scoopPostEntity);
+    }
+
+    @Transactional
+    public void deleteById(Long postId) {
+        postRepository.deleteById(postId);
+    }
+
+    @Transactional
+    public void updatePost(Long postId, String description, Double value, String cons) {
+        PostEntity postEntity = postRepository.findById(postId)
+                .orElseThrow(() -> new BusinessException(PostErrorMessage.POST_NOT_FOUND));
+
+        postEntity.updatePostContent(description, value, cons);
+    }
+
+    @Transactional
+    public void deleteAllPostCategoryByPostId(Long postId) {
+        List<PostCategoryEntity> postCategories = postCategoryRepository.findAllByPost_PostId(postId);
+        postCategoryRepository.deleteAll(postCategories);
+    }
+
+    @Transactional
+    public void deleteAllMenusByPostId(Long postId) {
+        List<MenuEntity> menus = menuRepository.findAllByPost_PostId(postId);
+        menuRepository.deleteAll(menus);
+    }
+
+    @Transactional
+    public void deleteAllPhotosByPostId(Long postId) {
+        List<PhotoEntity> photos = photoRepository.findAllByPost_PostId(postId);
+        photoRepository.deleteAll(photos);
     }
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/PostPersistenceAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/PostPersistenceAdapter.java
@@ -1,5 +1,6 @@
 package com.spoony.spoony_server.adapter.out.persistence.post;
 
+import com.spoony.spoony_server.application.port.out.post.PhotoPort;
 import com.spoony.spoony_server.domain.post.CategoryType;
 import com.spoony.spoony_server.adapter.out.persistence.place.db.PlaceEntity;
 import com.spoony.spoony_server.adapter.out.persistence.place.db.PlaceRepository;
@@ -31,7 +32,8 @@ import java.util.stream.Collectors;
 public class PostPersistenceAdapter implements
         PostPort,
         PostCategoryPort,
-        CategoryPort {
+        CategoryPort,
+        PhotoPort {
 
     private final PostRepository postRepository;
     private final PostCategoryRepository postCategoryRepository;
@@ -216,5 +218,12 @@ public class PostPersistenceAdapter implements
     public void deleteAllPhotosByPostId(Long postId) {
         List<PhotoEntity> photos = photoRepository.findAllByPost_PostId(postId);
         photoRepository.deleteAll(photos);
+    }
+
+    @Transactional
+    public List<String> getPhotoUrls(Long postId) {
+        return photoRepository.findAllByPost_PostId(postId).stream()
+                .map(PhotoEntity::getPhotoUrl)
+                .toList();
     }
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/MenuRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/MenuRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface MenuRepository extends JpaRepository<MenuEntity, Long> {
     Optional<List<MenuEntity>> findByPost_PostId(Long postId);
+    List<MenuEntity> findAllByPost_PostId(Long postId);
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PhotoRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PhotoRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface PhotoRepository extends JpaRepository<PhotoEntity, Long> {
     Optional<List<PhotoEntity>> findByPost_PostId(Long postId);
+    List<PhotoEntity> findAllByPost_PostId(Long postId);
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostCategoryRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostCategoryRepository.java
@@ -3,10 +3,12 @@ package com.spoony.spoony_server.adapter.out.persistence.post.db;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface PostCategoryRepository extends JpaRepository<PostCategoryEntity, Long> {
     Optional<PostCategoryEntity> findByPost_PostId(Long postID);
+    List<PostCategoryEntity> findAllByPost_PostId(Long postID);
 }
 

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostEntity.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostEntity.java
@@ -1,7 +1,10 @@
 package com.spoony.spoony_server.adapter.out.persistence.post.db;
 
+import com.spoony.spoony_server.adapter.out.persistence.feed.db.FeedEntity;
 import com.spoony.spoony_server.adapter.out.persistence.place.db.PlaceEntity;
+import com.spoony.spoony_server.adapter.out.persistence.report.db.ReportEntity;
 import com.spoony.spoony_server.adapter.out.persistence.user.db.UserEntity;
+import com.spoony.spoony_server.adapter.out.persistence.zzim.db.ZzimPostEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -12,6 +15,8 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -42,11 +47,36 @@ public class PostEntity {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
+    // Cascade 설정
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MenuEntity> menus = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PhotoEntity> photos = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostCategoryEntity> postCategories = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ReportEntity> reports = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<FeedEntity> feeds = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ZzimPostEntity> zzims = new ArrayList<>();
+
     @Builder
     public PostEntity(Long postId, UserEntity user, PlaceEntity place, String description, Double value, String cons) {
         this.postId = postId;
         this.user = user;
         this.place = place;
+        this.description = description;
+        this.value = value;
+        this.cons = cons;
+    }
+
+    public void updatePostContent(String description, Double value, String cons) {
         this.description = description;
         this.value = value;
         this.cons = cons;

--- a/src/main/java/com/spoony/spoony_server/application/port/command/post/PostDeleteCommand.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/command/post/PostDeleteCommand.java
@@ -1,0 +1,10 @@
+package com.spoony.spoony_server.application.port.command.post;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class PostDeleteCommand {
+    private final Long postId;
+}

--- a/src/main/java/com/spoony/spoony_server/application/port/command/post/PostUpdateCommand.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/command/post/PostUpdateCommand.java
@@ -1,0 +1,18 @@
+package com.spoony.spoony_server.application.port.command.post;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class PostUpdateCommand {
+    private final Long postId;
+    private final String description;
+    private final Double value;
+    private final String cons;
+    private final Long categoryId;
+    private final List<String> menuList;
+    private final List<String> photoUrlList;
+}

--- a/src/main/java/com/spoony/spoony_server/application/port/in/post/PostDeleteUseCase.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/in/post/PostDeleteUseCase.java
@@ -1,0 +1,7 @@
+package com.spoony.spoony_server.application.port.in.post;
+
+import com.spoony.spoony_server.application.port.command.post.PostDeleteCommand;
+
+public interface PostDeleteUseCase {
+    void deletePost(PostDeleteCommand command);
+}

--- a/src/main/java/com/spoony/spoony_server/application/port/in/post/PostDeleteUseCase.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/in/post/PostDeleteUseCase.java
@@ -4,4 +4,5 @@ import com.spoony.spoony_server.application.port.command.post.PostDeleteCommand;
 
 public interface PostDeleteUseCase {
     void deletePost(PostDeleteCommand command);
+    void deletePhotos(PostDeleteCommand command);
 }

--- a/src/main/java/com/spoony/spoony_server/application/port/in/post/PostUpdateUseCase.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/in/post/PostUpdateUseCase.java
@@ -1,0 +1,8 @@
+package com.spoony.spoony_server.application.port.in.post;
+
+import com.spoony.spoony_server.application.port.command.post.PostUpdateCommand;
+import com.spoony.spoony_server.domain.post.Post;
+
+public interface PostUpdateUseCase {
+    public void updatePost(PostUpdateCommand command);
+}

--- a/src/main/java/com/spoony/spoony_server/application/port/out/post/PhotoPort.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/out/post/PhotoPort.java
@@ -1,0 +1,7 @@
+package com.spoony.spoony_server.application.port.out.post;
+
+import java.util.List;
+
+public interface PhotoPort {
+    List<String> getPhotoUrls(Long postId);
+}

--- a/src/main/java/com/spoony/spoony_server/application/port/out/post/PostDeletePort.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/out/post/PostDeletePort.java
@@ -1,0 +1,7 @@
+package com.spoony.spoony_server.application.port.out.post;
+
+import java.util.List;
+
+public interface PostDeletePort {
+    void deleteImagesFromS3(List<String> imageUrls);
+}

--- a/src/main/java/com/spoony/spoony_server/application/port/out/post/PostPort.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/out/post/PostPort.java
@@ -19,4 +19,9 @@ public interface PostPort {
     void saveMenu(Menu menu);
     void savePhoto(Photo photo);
     void saveScoopPost(User user, Post post);
+    void deleteById(Long postId);
+    void updatePost(Long postId, String description, Double value, String cons);
+    void deleteAllPostCategoryByPostId(Long postId);
+    void deleteAllMenusByPostId(Long postId);
+    void deleteAllPhotosByPostId(Long postId);
 }


### PR DESCRIPTION
### 📝 Work Description
- 게시물 수정, 삭제 API를 구현하였습니다.

### ⚙️ Issue
[//]: # (연관된 이슈 번호)
- closed #124 

### 🔨 Changes
- API가 추가되었습니다.

### 🔍 PR Point
- 게시물 수정의 경우, 사진, 메뉴, 카테고리 등 독립적인 테이블로 관리되는 항목들은 삭제 후 재생성하는 방식으로 구현하였습니다.