### PR TITLE
[FIX] API 명세 회의 내용 반영 1

### DIFF
--- a/src/main/java/com/spoony/spoony_server/adapter/dto/user/FollowListResponseDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/dto/user/FollowListResponseDTO.java
@@ -1,0 +1,9 @@
+package com.spoony.spoony_server.adapter.dto.user;
+
+import java.util.List;
+
+public record FollowListResponseDTO(
+        int count,
+        List<UserSimpleResponseDTO> users
+) {
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/dto/user/UserDetailResponseDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/dto/user/UserDetailResponseDTO.java
@@ -2,7 +2,7 @@ package com.spoony.spoony_server.adapter.dto.user;
 
 public record UserDetailResponseDTO(
         String userName,
-        String region,
+        String regionName,
         String introduction,
         Long followerCount,
         Long followingCount,

--- a/src/main/java/com/spoony/spoony_server/adapter/dto/user/UserResponseDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/dto/user/UserResponseDTO.java
@@ -11,5 +11,9 @@ public record UserResponseDTO(long userId,
                               String regionName,
                               String introduction,
                               LocalDateTime createdAt,
-                              LocalDateTime updatedAt) {
+                              LocalDateTime updatedAt,
+                              Long followerCount,
+                              Long followingCount,
+                              boolean isFollowing,
+                              Long reviewCount) {
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/dto/user/UserSimpleResponseDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/dto/user/UserSimpleResponseDTO.java
@@ -3,7 +3,7 @@ package com.spoony.spoony_server.adapter.dto.user;
 public record  UserSimpleResponseDTO (
     Long userId,
     String username,
-    String location,
+    String regionName,
     boolean isFollowing
 ){
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/dto/zzim/ZzimFocusResponseDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/dto/zzim/ZzimFocusResponseDTO.java
@@ -10,6 +10,7 @@ public record ZzimFocusResponseDTO(long placeId,
                                    String authorName,
                                    String authorRegionName,
                                    long postId,
+                                   String description,
                                    Long zzimCount,
                                    List<String> photoUrlList
 ) {

--- a/src/main/java/com/spoony/spoony_server/application/port/in/user/UserGetUseCase.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/in/user/UserGetUseCase.java
@@ -7,14 +7,13 @@ import com.spoony.spoony_server.domain.user.User;
 import java.util.List;
 
 public interface UserGetUseCase {
-    UserResponseDTO getUserInfo(UserGetCommand command);
-    UserDetailResponseDTO getUserDetailInfo(UserGetCommand userGetCommand, UserFollowCommand userFollowCommand);
+    UserResponseDTO getUserInfo(UserGetCommand userGetCommand, UserFollowCommand userFollowCommand );
     UserProfileUpdateResponseDTO getUserProfileInfo(UserGetCommand userGetCommand);
     List<UserSimpleResponseDTO> getUserSimpleInfo(UserGetCommand command);
     List<UserSimpleResponseDTO> getUserSimpleInfoBySearch(UserSearchCommand command);
     Boolean isUsernameDuplicate(UserNameCheckCommand command);
     UserSearchHistoryResponseDTO getUserSearchHistory(UserGetCommand command);
-    List<UserSimpleResponseDTO> getFollowers(Long userId);
-    List<UserSimpleResponseDTO> getFollowings(Long userId);
+    FollowListResponseDTO getFollowers(Long userId);
+    FollowListResponseDTO getFollowings(Long userId);
 
 }

--- a/src/main/java/com/spoony/spoony_server/application/service/zzim/ZzimPostService.java
+++ b/src/main/java/com/spoony/spoony_server/application/service/zzim/ZzimPostService.java
@@ -137,6 +137,7 @@ public class ZzimPostService implements
                             post.getUser().getUserName(),
                             post.getUser().getRegion().getRegionName(),
                             post.getPostId(),
+                            post.getDescription(),
                             zzimCount,
                             photoUrlList
                     );


### PR DESCRIPTION
### 📝 Work Description
- 자잘한 것들 적용합니다.
1. region 명으로 통일(팔로잉,팔로워 api /유저 검색 api 등)

2. 사용자 정보 조회 api -> 통합(detail버젼 삭제) / response에서 빠진 부분 채우기 /response 에 마이페이지 리뷰수 -> 추가

3. 팔로잉/팔로워 목록 조회 -> 전체 팔로잉 수/팔로워 수 추가

4. 사용자/게시물 신고 api -> userId는 토큰으로 대체

5. 북마크 장소 리스트를 조회하는 API -> 리뷰 내용 추가

### ⚙️ Issue
[//]: #142 
- closed #142 

### 🔨 Changes
- 응답 형식 등 변경
