### PR TITLE
[FEAT] 차단 유저 비즈니스 로직 반영

### DIFF
--- a/src/main/java/com/spoony/spoony_server/adapter/dto/block/BlockUserRequestDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/dto/block/BlockUserRequestDTO.java
@@ -1,0 +1,4 @@
+package com.spoony.spoony_server.adapter.dto.block;
+
+public record BlockUserRequestDTO(Long targetUserId) {
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/in/web/feed/FeedController.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/in/web/feed/FeedController.java
@@ -22,6 +22,8 @@ public class FeedController {
 
     private final FeedGetUseCase feedGetUseCase;
 
+
+
     @GetMapping("/{categoryId}")
     @Operation(summary = "피드 조회 API", description = "사용자의 피드를 카테고리 단위로 조회하는 API")
     public ResponseEntity<ResponseDTO<FeedListResponseDTO>> getFeedListByUserId(

--- a/src/main/java/com/spoony/spoony_server/adapter/in/web/post/PostController.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/in/web/post/PostController.java
@@ -158,8 +158,6 @@ public class PostController {
         UserGetCommand userGetCommand = new UserGetCommand(userId);
         PostSearchCommand searchCommand = new PostSearchCommand(query);
 
-
-
         PostSearchResultListDTO postSearchList = postSearchUseCase.searchReviewsByQuery(userGetCommand,searchCommand);
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(postSearchList));
     }

--- a/src/main/java/com/spoony/spoony_server/adapter/in/web/post/PostController.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/in/web/post/PostController.java
@@ -7,6 +7,7 @@ import com.spoony.spoony_server.application.port.command.post.*;
 import com.spoony.spoony_server.application.port.command.user.UserGetCommand;
 import com.spoony.spoony_server.application.port.command.user.UserNameCheckCommand;
 import com.spoony.spoony_server.application.port.command.user.UserSearchCommand;
+import com.spoony.spoony_server.application.port.in.block.BlockedUserGetUseCase;
 import com.spoony.spoony_server.application.port.in.post.*;
 import com.spoony.spoony_server.domain.post.Post;
 import com.spoony.spoony_server.global.auth.annotation.UserId;
@@ -36,7 +37,7 @@ public class PostController {
     private final PostDeleteUseCase postDeleteUseCase;
     private final PostUpdateUseCase postUpdateUseCase;
     private final PostSearchUseCase postSearchUseCase;
-
+    private final BlockedUserGetUseCase blockedUserGetUseCase;
     @GetMapping("/{postId}")
     @Operation(summary = "게시물 조회 API", description = "특정 게시물의 상세 정보를 조회하는 API")
     public ResponseEntity<ResponseDTO<PostResponseDTO>> getPost(
@@ -151,12 +152,17 @@ public class PostController {
     @GetMapping("/search")
     @Operation(summary = "리뷰 검색 API", description = "검색어를 통해 리뷰를 검색하는 API")
     public ResponseEntity<ResponseDTO<PostSearchResultListDTO>> searchLocations(
+            @UserId Long userId,
             @RequestParam String query) {
-        PostSearchCommand command = new PostSearchCommand(query);
-        PostSearchResultListDTO postSearchList = postSearchUseCase.searchReviewsByQuery(command);
+
+        UserGetCommand userGetCommand = new UserGetCommand(userId);
+        PostSearchCommand searchCommand = new PostSearchCommand(query);
+
+
+
+        PostSearchResultListDTO postSearchList = postSearchUseCase.searchReviewsByQuery(userGetCommand,searchCommand);
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(postSearchList));
     }
 
 
 }
-

--- a/src/main/java/com/spoony/spoony_server/adapter/in/web/zzim/ZzimPostController.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/in/web/zzim/ZzimPostController.java
@@ -1,5 +1,6 @@
 package com.spoony.spoony_server.adapter.in.web.zzim;
 
+import com.spoony.spoony_server.application.port.command.block.BlockCheckCommand;
 import com.spoony.spoony_server.application.port.command.zzim.*;
 import com.spoony.spoony_server.application.port.in.zzim.ZzimAddUseCase;
 import com.spoony.spoony_server.application.port.in.zzim.ZzimGetUseCase;
@@ -9,6 +10,7 @@ import com.spoony.spoony_server.global.dto.ResponseDTO;
 import com.spoony.spoony_server.adapter.dto.zzim.ZzimPostAddRequestDTO;
 import com.spoony.spoony_server.adapter.dto.zzim.ZzimCardListResponseDTO;
 import com.spoony.spoony_server.adapter.dto.zzim.ZzimFocusListResponseDTO;
+import com.spoony.spoony_server.global.message.business.BlockErrorMessage;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -36,6 +38,13 @@ public class ZzimPostController {
         zzimAddUseCase.addZzimPost(command);
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(null));
     }
+
+//    BlockCheckCommand blockCheckCommand = new BlockCheckCommand(userId, targetUserId);
+//
+//        if (blockCheckUseCase.isBlocked(blockCheckCommand)) {
+//        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+//                .body(ResponseDTO.fail(BlockErrorMessage.USER_BLOCKED));
+//    }
 
     @GetMapping
     @Operation(summary = "북마크 조회 API", description = "북마크 장소 리스트를 조회하는 API")

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/block/BlockPersistenceAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/block/BlockPersistenceAdapter.java
@@ -1,0 +1,61 @@
+package com.spoony.spoony_server.adapter.out.persistence.block;
+
+import com.spoony.spoony_server.adapter.out.persistence.block.db.BlockEntity;
+import com.spoony.spoony_server.adapter.out.persistence.block.db.BlockRepository;
+import com.spoony.spoony_server.adapter.out.persistence.user.db.FollowEntity;
+import com.spoony.spoony_server.adapter.out.persistence.user.db.UserEntity;
+import com.spoony.spoony_server.adapter.out.persistence.user.db.UserRepository;
+import com.spoony.spoony_server.application.port.command.block.BlockUserCommand;
+import com.spoony.spoony_server.application.port.in.block.BlockUserCreateUseCase;
+import com.spoony.spoony_server.application.port.out.block.BlockPort;
+import com.spoony.spoony_server.domain.block.Block;
+import com.spoony.spoony_server.global.exception.BusinessException;
+import com.spoony.spoony_server.global.message.business.UserErrorMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+@Repository
+@Transactional
+@RequiredArgsConstructor
+public class BlockPersistenceAdapter implements BlockPort {
+
+    private final UserRepository userRepository;
+    private final BlockRepository blockRepository;
+
+    @Override
+    public void saveUserBlockRelation(Long fromUserId, Long toUserId) {
+        UserEntity fromUserEntity = userRepository.findById(fromUserId).orElseThrow(() -> new BusinessException(UserErrorMessage.USER_NOT_FOUND));
+
+        UserEntity toUserEntity = userRepository.findById(toUserId).orElseThrow(() -> new BusinessException(UserErrorMessage.USER_NOT_FOUND));
+
+        BlockEntity blockEntity = BlockEntity.builder().blocker(fromUserEntity).blocked(toUserEntity).build();
+
+        blockRepository.save(blockEntity);
+
+    }
+
+    @Override
+    public void deleteUserBlockRelation(Long fromUserId, Long toUserId) {
+        blockRepository.deleteByBlocker_userIdAndBlocked_userId(fromUserId, toUserId);
+    }
+
+    @Override
+    public boolean existsBlockUserRelation(Long fromUserId, Long toUserId) {
+        return blockRepository.existsByBlocker_userIdAndBlocked_userId(fromUserId,toUserId);
+
+    }
+
+    @Override
+    public List<Long> getBlockedUserIds(Long userId) {
+        return blockRepository.findBlockedIdsByBlockerId(userId);
+    }
+
+//    @Override
+//    public List<Long> findBlockedIdsByBlockerId(Long userId) {
+//        return blockRepository.findBlocked_userIdByBlocker_userId(userId);
+//    }
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/block/BlockPersistenceAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/block/BlockPersistenceAdapter.java
@@ -51,7 +51,7 @@ public class BlockPersistenceAdapter implements BlockPort {
 
     @Override
     public List<Long> getBlockedUserIds(Long userId) {
-        return blockRepository.findBlockedIdsByBlockerId(userId);
+        return blockRepository.findBlockedUserIdsByBlockerUserId(userId);
     }
 
 //    @Override

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/block/db/BlockEntity.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/block/db/BlockEntity.java
@@ -1,0 +1,37 @@
+package com.spoony.spoony_server.adapter.out.persistence.block.db;
+
+
+import com.spoony.spoony_server.adapter.out.persistence.user.db.UserEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "block")
+public class BlockEntity {
+
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long blockId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "blocker_id")
+    private UserEntity blocker;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "blocked_id")
+    private UserEntity blocked;
+
+    @Builder
+    public BlockEntity(Long blockId,UserEntity blocker,UserEntity blocked){
+        this.blockId = blockId;
+        this.blocker = blocker;
+        this.blocked = blocked;
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/block/db/BlockRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/block/db/BlockRepository.java
@@ -3,6 +3,8 @@ package com.spoony.spoony_server.adapter.out.persistence.block.db;
 
 import com.spoony.spoony_server.adapter.out.persistence.user.db.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -16,8 +18,9 @@ public interface BlockRepository extends JpaRepository<BlockEntity, Long> {
     // 차단 관계가 존재하는지 확인
     boolean existsByBlocker_userIdAndBlocked_userId(Long fromUserId, Long toUserId);
 
-    // 특정 userId가 차단한 user들의 ID 목록을 반환
-    List<Long> findBlockedIdsByBlockerId(Long blockerId);
+    @Query("SELECT b.blocked.userId FROM BlockEntity b WHERE b.blocker.userId = :blockerUserId")
+    List<Long> findBlockedUserIdsByBlockerUserId(@Param("blockerUserId") Long blockerUserId);
+
 
 
 //    void deleteByBlocker_UserIdAndBlocked_UserId(Long fromUserId, Long toUserId);

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/block/db/BlockRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/block/db/BlockRepository.java
@@ -1,0 +1,26 @@
+package com.spoony.spoony_server.adapter.out.persistence.block.db;
+
+
+import com.spoony.spoony_server.adapter.out.persistence.user.db.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface BlockRepository extends JpaRepository<BlockEntity, Long> {
+
+    // 차단 관계를 삭제할 때, blocker와 blocked의 userId를 기준으로 삭제
+    void deleteByBlocker_userIdAndBlocked_userId(Long fromUserId, Long toUserId);
+
+    // 차단 관계가 존재하는지 확인
+    boolean existsByBlocker_userIdAndBlocked_userId(Long fromUserId, Long toUserId);
+
+    // 특정 userId가 차단한 user들의 ID 목록을 반환
+    List<Long> findBlockedIdsByBlockerId(Long blockerId);
+
+
+//    void deleteByBlocker_UserIdAndBlocked_UserId(Long fromUserId, Long toUserId);
+//    boolean existsByBlockerIdAndBlockedId(Long fromUserId, Long toUserId);
+//    List<Long> findBlockedIdsByBlockerId(Long blockerId);
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostRepository.java
@@ -12,4 +12,5 @@ public interface PostRepository extends JpaRepository<PostEntity, Long> {
     List<PostEntity> findByUser_UserId(Long userId);
     Long countByUser_UserId(Long userId);
     List<PostEntity> findByDescriptionContaining(String query);
+
 }

--- a/src/main/java/com/spoony/spoony_server/application/port/command/block/BlockCheckCommand.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/command/block/BlockCheckCommand.java
@@ -1,0 +1,12 @@
+package com.spoony.spoony_server.application.port.command.block;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class BlockCheckCommand {
+    private final Long userId;
+    private final Long targetUserId;
+}

--- a/src/main/java/com/spoony/spoony_server/application/port/command/block/BlockUserCommand.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/command/block/BlockUserCommand.java
@@ -1,0 +1,12 @@
+package com.spoony.spoony_server.application.port.command.block;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class BlockUserCommand {
+    private final Long userId;
+    private final Long targetUserId;
+}
+

--- a/src/main/java/com/spoony/spoony_server/application/port/command/post/PostSearchCommand.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/command/post/PostSearchCommand.java
@@ -7,4 +7,5 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PostSearchCommand {
     private final String query;
+
 }

--- a/src/main/java/com/spoony/spoony_server/application/port/command/user/UserSearchCommand.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/command/user/UserSearchCommand.java
@@ -7,4 +7,5 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class UserSearchCommand {
     private final String query;
+
 }

--- a/src/main/java/com/spoony/spoony_server/application/port/in/block/BlockCheckUseCase.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/in/block/BlockCheckUseCase.java
@@ -1,0 +1,7 @@
+package com.spoony.spoony_server.application.port.in.block;
+
+import com.spoony.spoony_server.application.port.command.block.BlockCheckCommand;
+
+public interface BlockCheckUseCase {
+    boolean isBlocked(BlockCheckCommand command);
+}

--- a/src/main/java/com/spoony/spoony_server/application/port/in/block/BlockUserCreateUseCase.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/in/block/BlockUserCreateUseCase.java
@@ -1,0 +1,10 @@
+package com.spoony.spoony_server.application.port.in.block;
+
+import com.spoony.spoony_server.application.port.command.block.BlockUserCommand;
+import com.spoony.spoony_server.application.port.command.user.UserFollowCommand;
+
+
+public interface BlockUserCreateUseCase {
+    void createUserBlock(BlockUserCommand command);
+    void deleteUserBlock(BlockUserCommand command);
+}

--- a/src/main/java/com/spoony/spoony_server/application/port/in/block/BlockedUserGetUseCase.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/in/block/BlockedUserGetUseCase.java
@@ -1,0 +1,11 @@
+package com.spoony.spoony_server.application.port.in.block;
+
+import com.spoony.spoony_server.application.port.command.block.BlockCheckCommand;
+import com.spoony.spoony_server.application.port.command.user.UserGetCommand;
+
+import java.util.List;
+
+public interface BlockedUserGetUseCase {
+    List<Long> searchUsersByQuery(UserGetCommand command);
+
+}

--- a/src/main/java/com/spoony/spoony_server/application/port/in/post/PostSearchUseCase.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/in/post/PostSearchUseCase.java
@@ -3,9 +3,11 @@ package com.spoony.spoony_server.application.port.in.post;
 import com.spoony.spoony_server.adapter.dto.post.PostSearchResultListDTO;
 import com.spoony.spoony_server.adapter.dto.user.UserSearchResultListDTO;
 import com.spoony.spoony_server.application.port.command.post.PostSearchCommand;
+import com.spoony.spoony_server.application.port.command.user.UserGetCommand;
 import com.spoony.spoony_server.application.port.command.user.UserSearchCommand;
 
 public interface PostSearchUseCase {
-    PostSearchResultListDTO searchReviewsByQuery(PostSearchCommand command);
+    PostSearchResultListDTO searchReviewsByQuery(UserGetCommand userGetCommand,PostSearchCommand postSearchCommand);
 }
+
 

--- a/src/main/java/com/spoony/spoony_server/application/port/in/user/UserGetUseCase.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/in/user/UserGetUseCase.java
@@ -13,7 +13,7 @@ public interface UserGetUseCase {
     List<UserSimpleResponseDTO> getUserSimpleInfoBySearch(UserSearchCommand command);
     Boolean isUsernameDuplicate(UserNameCheckCommand command);
     UserSearchHistoryResponseDTO getUserSearchHistory(UserGetCommand command);
-    FollowListResponseDTO getFollowers(Long userId);
-    FollowListResponseDTO getFollowings(Long userId);
+    FollowListResponseDTO getFollowers(UserGetCommand command);
+    FollowListResponseDTO getFollowings(UserGetCommand command);
 
 }

--- a/src/main/java/com/spoony/spoony_server/application/port/in/user/UserSearchUseCase.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/in/user/UserSearchUseCase.java
@@ -3,9 +3,10 @@ package com.spoony.spoony_server.application.port.in.user;
 import com.spoony.spoony_server.adapter.dto.location.LocationResponseListDTO;
 import com.spoony.spoony_server.adapter.dto.user.UserSearchResultListDTO;
 import com.spoony.spoony_server.application.port.command.location.LocationSearchCommand;
+import com.spoony.spoony_server.application.port.command.user.UserGetCommand;
 import com.spoony.spoony_server.application.port.command.user.UserSearchCommand;
 
 public interface UserSearchUseCase {
-    UserSearchResultListDTO searchUsersByQuery(UserSearchCommand command);
+    UserSearchResultListDTO searchUsersByQuery(UserGetCommand command,UserSearchCommand searchCommand);
 }
 

--- a/src/main/java/com/spoony/spoony_server/application/port/out/block/BlockPort.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/out/block/BlockPort.java
@@ -1,0 +1,15 @@
+package com.spoony.spoony_server.application.port.out.block;
+
+import com.spoony.spoony_server.domain.block.Block;
+import com.spoony.spoony_server.domain.report.Report;
+import com.spoony.spoony_server.domain.report.UserReport;
+
+import java.util.List;
+
+public interface BlockPort {
+    void saveUserBlockRelation(Long fromUserId, Long toUserId);
+    void deleteUserBlockRelation(Long fromUserId, Long toUserId);
+    boolean existsBlockUserRelation(Long fromUserId, Long toUserId);
+    List<Long> getBlockedUserIds(Long userId);
+}
+

--- a/src/main/java/com/spoony/spoony_server/application/port/out/report/ReportPort.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/out/report/ReportPort.java
@@ -7,3 +7,5 @@ public interface ReportPort {
     void saveReport(Report report);
     void saveUserReport(UserReport userReport);
 }
+
+

--- a/src/main/java/com/spoony/spoony_server/application/service/block/BlockService.java
+++ b/src/main/java/com/spoony/spoony_server/application/service/block/BlockService.java
@@ -1,0 +1,46 @@
+package com.spoony.spoony_server.application.service.block;
+
+import com.spoony.spoony_server.application.port.command.block.BlockCheckCommand;
+import com.spoony.spoony_server.application.port.command.block.BlockUserCommand;
+import com.spoony.spoony_server.application.port.command.user.UserGetCommand;
+import com.spoony.spoony_server.application.port.in.block.BlockCheckUseCase;
+import com.spoony.spoony_server.application.port.in.block.BlockUserCreateUseCase;
+import com.spoony.spoony_server.application.port.in.block.BlockedUserGetUseCase;
+import com.spoony.spoony_server.application.port.out.block.BlockPort;
+import com.spoony.spoony_server.application.port.out.user.UserPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BlockService implements BlockUserCreateUseCase, BlockCheckUseCase , BlockedUserGetUseCase {
+    private final BlockPort blockPort;
+    private final UserPort userPort;
+
+    @Transactional
+    @Override
+    public void createUserBlock(BlockUserCommand command) {
+        blockPort.saveUserBlockRelation(command.getUserId(), command.getTargetUserId());
+    }
+    @Transactional
+    @Override
+    public void deleteUserBlock(BlockUserCommand command) {
+        blockPort.deleteUserBlockRelation(command.getUserId(),command.getTargetUserId());
+    }
+
+    @Override
+    public boolean isBlocked(BlockCheckCommand command) {
+        return blockPort.existsBlockUserRelation(command.getUserId(), command.getTargetUserId());
+    }
+
+    @Override
+    public List<Long> searchUsersByQuery(UserGetCommand command) {
+        return blockPort.getBlockedUserIds(command.getUserId());
+    }
+
+
+}
+

--- a/src/main/java/com/spoony/spoony_server/application/service/block/BlockService.java
+++ b/src/main/java/com/spoony/spoony_server/application/service/block/BlockService.java
@@ -24,6 +24,7 @@ public class BlockService implements BlockUserCreateUseCase, BlockCheckUseCase ,
     @Override
     public void createUserBlock(BlockUserCommand command) {
         blockPort.saveUserBlockRelation(command.getUserId(), command.getTargetUserId());
+        userPort.deleteFollowRelation(command.getUserId(),command.getTargetUserId());
     }
     @Transactional
     @Override

--- a/src/main/java/com/spoony/spoony_server/application/service/report/ReportService.java
+++ b/src/main/java/com/spoony/spoony_server/application/service/report/ReportService.java
@@ -70,15 +70,3 @@ public class ReportService implements ReportCreateUseCase {
         reportPort.saveUserReport(userReport);
     }
 }
-
-
-//
-//    Long postId = command.getPostId();
-//    Long userId = command.getUserId();
-//
-//    Post post = postPort.findPostById(postId);
-//    User user = userPort.findUserById(userId);
-//
-//    Report report = new Report(reportType,command.getReportDetail(),post,user);
-//    reportPort.saveReport(report);
-//}

--- a/src/main/java/com/spoony/spoony_server/domain/block/Block.java
+++ b/src/main/java/com/spoony/spoony_server/domain/block/Block.java
@@ -1,0 +1,13 @@
+package com.spoony.spoony_server.domain.block;
+
+import com.spoony.spoony_server.domain.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class Block {
+    private Long blockId;
+    private User blocker;
+    private User blocked;
+}

--- a/src/main/java/com/spoony/spoony_server/global/message/business/BlockErrorMessage.java
+++ b/src/main/java/com/spoony/spoony_server/global/message/business/BlockErrorMessage.java
@@ -1,0 +1,17 @@
+package com.spoony.spoony_server.global.message.business;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum BlockErrorMessage implements DefaultErrorMessage {
+
+
+    USER_BLOCKED(HttpStatus.FORBIDDEN,"차단된 사용자입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}


### PR DESCRIPTION
### 📝 Work Description
- 차단한 유저에 대한 로직 반영했습니다
- Block 도메인을 별도로 분리했습니다.

### ⚙️ Issue
[//]: # (연관된 이슈 번호)
- closed #146 

### 🔨 Changes
- User
  - 특정 사용자 리뷰 전체 조회 API (Controller에서 처리)
  - 특정 사용자 상세 정보 조회 API (Controller에서 처리)
   => 단순히 상대방 userId 기반으로 차단 검증 후 예외 던짐
  
  - 유저 검색 (Service에서 처리)
  => 위보다 좀더 복잡한~

- Post
  - 리뷰 검색 (Service에서 처리)

-Zzim
  - 특정 장소의 북마크 리스트 조회 (Service에서 처리)

- Follow
  - 팔로우 해제 (Service에서 처리)


### 🔍 PR Point
- 차단 로직이 각 도메인(Service 또는 Controller)에서 어떻게 처리되고 있는지 확인 부탁드립니다.
  - 간단한 조회는 Controller에서, 로직이 복잡하거나 재사용 가능한 경우는 Service에서 처리하고 있습니다.
- Block 도메인을 별도로 분리함에 따라 기존 User 도메인과의 의존성을 최소화하려 했습니다. 구조적인 측면에서도 피드백 환영입니다.
- 도메인별로 차단 유저에 대한 접근을 어떻게 제한하고 있는지 흐름 파악해 주세요.
  - 예: 리뷰 검색 시 차단 유저의 글이 보이지 않도록 필터링 처리