### PR TITLE
[FEAT] 페이징 구현 + region카테고리 필터 오류 수정

### DIFF
--- a/src/main/java/com/spoony/spoony_server/adapter/dto/post/FilteredFeedResponseListDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/dto/post/FilteredFeedResponseListDTO.java
@@ -2,5 +2,5 @@ package com.spoony.spoony_server.adapter.dto.post;
 
 import java.util.List;
 
-public record FilteredFeedResponseListDTO(List<FilteredFeedResponseDTO> filteredFeedResponseDTOList) {
+public record FilteredFeedResponseListDTO(List<FilteredFeedResponseDTO> filteredFeedResponseDTOList,Long nextCursor) {
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/in/web/feed/FeedController.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/in/web/feed/FeedController.java
@@ -94,7 +94,9 @@ public class FeedController {
             @RequestParam(required = false) List<Long> categoryIds,
             @RequestParam(required = false) List<Long> regionIds,
             @RequestParam(required = false) List<AgeGroup> ageGroups,
-            @RequestParam(defaultValue = "createdAt") String sortBy
+            @RequestParam(defaultValue = "createdAt") String sortBy,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "5") int size
     ) {
         Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -134,7 +136,7 @@ public class FeedController {
             logger.info("ageGroups가 비어 있어 null로 설정됨");
         }
         // 4. FeedFilterCommand에 필터된 카테고리와 지역 정보, 정렬 기준을 전달
-        FeedFilterCommand command = new FeedFilterCommand(categoryIds, regionIds, ageGroups, sortBy, isLocalReview);
+        FeedFilterCommand command = new FeedFilterCommand(categoryIds, regionIds, ageGroups, sortBy, isLocalReview, cursor, size);
         logger.info("🟢FeedFilterCommand 생성 완료: {}", command);
         // 5. 필터링된 피드를 가져오기 위해 UseCase 호출
         try {

--- a/src/main/java/com/spoony/spoony_server/application/port/command/feed/FeedFilterCommand.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/command/feed/FeedFilterCommand.java
@@ -16,4 +16,7 @@ public class FeedFilterCommand {
     private final String sortBy;
     private final boolean isLocalReview;
 
+    private final Long cursor;
+    private final int size;
+
 }

--- a/src/main/java/com/spoony/spoony_server/application/port/out/post/PostPort.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/out/post/PostPort.java
@@ -27,7 +27,7 @@ public interface PostPort {
     void deleteAllMenusByPostId(Long postId);
     void deleteAllPhotosByPhotoUrl(List<String> deletePhotoUrlList);
 
-    List<Post> findFilteredPosts(List<Long> categoryIds, List<Long> regionIds,  List<AgeGroup>ageGroups,String sortBy,  boolean isLocalReview);
+    List<Post> findFilteredPosts(List<Long> categoryIds, List<Long> regionIds,  List<AgeGroup>ageGroups,String sortBy,  boolean isLocalReview,Long cursor,int size);
 
     Long countPostsByUserId(Long userId);
     List<Post> findByPostDescriptionContaining(String query);

--- a/src/main/java/com/spoony/spoony_server/application/service/feed/FeedService.java
+++ b/src/main/java/com/spoony/spoony_server/application/service/feed/FeedService.java
@@ -105,6 +105,8 @@ public class FeedService implements FeedGetUseCase {
         List<Long> categoryIds = command.getCategoryIds();
         boolean isLocalReviewFlag = command.isLocalReview();
         List<AgeGroup> ageGroups = command.getAgeGroups();
+        Long cursor = command.getCursor();
+        int size = command.getSize();
 
         try {
             if (isLocalReviewFlag && categoryIds.size() == 1 && categoryIds.contains(2L)) {
@@ -114,7 +116,9 @@ public class FeedService implements FeedGetUseCase {
                         command.getRegionIds(),
                         ageGroups,
                         command.getSortBy(),
-                        isLocalReviewFlag // 로컬리뷰 플래그 그대로 전달
+                        isLocalReviewFlag,
+                        cursor,
+                        size
                 );
             } else {
                 logger.info(isLocalReviewFlag ? "✅✅✅ 로컬리뷰: 필터링 로직 실행" : "일반리뷰: 필터링 로직 실행");
@@ -123,7 +127,9 @@ public class FeedService implements FeedGetUseCase {
                         command.getRegionIds(),
                         ageGroups,
                         command.getSortBy(),
-                        isLocalReviewFlag
+                        isLocalReviewFlag,
+                        cursor,
+                        size
                 );
             }
         } catch (Exception e) {
@@ -163,7 +169,12 @@ public class FeedService implements FeedGetUseCase {
                 })
                 .collect(Collectors.toList());
 
-        return new FilteredFeedResponseListDTO(feedResponseList);
+        // ✅ nextCursor 계산 (마지막 postId)
+        Long nextCursor = filteredPosts.isEmpty() ? null :
+                filteredPosts.get(filteredPosts.size() - 1).getPostId();
+
+        logger.info("다음 커서(nextCursor): {}", nextCursor);
+        return new FilteredFeedResponseListDTO(feedResponseList,nextCursor);
     }
 
 


### PR DESCRIPTION
### 📝 Work Description

**페이징 구현**
- 커서 기반 페이징 구현 (Cursor-based pagination)

- 한 페이지당 size = 10

- `sortBy=zzimCount 조건이 있을 경우`:
  - 찜 수(zzimCount)를 기준으로 내림차순 정렬
  - 동일한 zzimCount 값을 가진 게시물들이 있을 경우, 그들 간의 순서는 최신순(createdAt 내림차순) 으로 정렬
  - 따라서, 최종 정렬 기준은 ORDER BY zzimCount DESC, createdAt DESC

**지역 필터링 문제 해결**
- regionIds가 주어졌을 때, 해당 지역을 가진 게시물만을 반환하고, null인 지역을 포함하지 않도록 nullRegionPredicate를 제거

### ⚙️ Issue
[//]: # (연관된 이슈 번호)
- closed #170 
