### PR TITLE
[FEAT] 탐색 피드 리스트 조회시, 리뷰 작성자 식별 로직 추가

### DIFF
--- a/src/main/java/com/spoony/spoony_server/adapter/dto/post/FilteredFeedResponseDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/dto/post/FilteredFeedResponseDTO.java
@@ -13,7 +13,9 @@ public record FilteredFeedResponseDTO(
         Long zzimCount,
         List<String> photoUrlList,
         LocalDateTime createdAt,
-        boolean isLocalReview
+        boolean isLocalReview,
+        boolean isMine
+
 
 ) {
 

--- a/src/main/java/com/spoony/spoony_server/adapter/in/web/feed/FeedController.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/in/web/feed/FeedController.java
@@ -91,6 +91,7 @@ public class FeedController {
     """
     )
     public ResponseEntity<ResponseDTO<FilteredFeedResponseListDTO>> getFeeds(
+            @UserId Long currentUserId,
             @RequestParam(required = false) List<Long> categoryIds,
             @RequestParam(required = false) List<Long> regionIds,
             @RequestParam(required = false) List<AgeGroup> ageGroups,
@@ -136,7 +137,7 @@ public class FeedController {
             logger.info("ageGroups가 비어 있어 null로 설정됨");
         }
         // 4. FeedFilterCommand에 필터된 카테고리와 지역 정보, 정렬 기준을 전달
-        FeedFilterCommand command = new FeedFilterCommand(categoryIds, regionIds, ageGroups, sortBy, isLocalReview, cursor, size);
+        FeedFilterCommand command = new FeedFilterCommand(categoryIds, regionIds, ageGroups, sortBy, isLocalReview, cursor, size,currentUserId);
         logger.info("🟢FeedFilterCommand 생성 완료: {}", command);
         // 5. 필터링된 피드를 가져오기 위해 UseCase 호출
         try {

--- a/src/main/java/com/spoony/spoony_server/application/port/command/feed/FeedFilterCommand.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/command/feed/FeedFilterCommand.java
@@ -18,5 +18,5 @@ public class FeedFilterCommand {
 
     private final Long cursor;
     private final int size;
-
+    private final Long currentUserId;
 }

--- a/src/main/java/com/spoony/spoony_server/application/service/feed/FeedService.java
+++ b/src/main/java/com/spoony/spoony_server/application/service/feed/FeedService.java
@@ -107,6 +107,7 @@ public class FeedService implements FeedGetUseCase {
         List<AgeGroup> ageGroups = command.getAgeGroups();
         Long cursor = command.getCursor();
         int size = command.getSize();
+        Long currentUserId = command.getCurrentUserId();
 
         try {
             if (isLocalReviewFlag && categoryIds.size() == 1 && categoryIds.contains(2L)) {
@@ -139,9 +140,12 @@ public class FeedService implements FeedGetUseCase {
 
         logger.info("필터링된 게시물 수: {}", filteredPosts.size());
 
+
         List<FilteredFeedResponseDTO> feedResponseList = filteredPosts.stream()
                 .map(post -> {
                     User author = post.getUser();
+                    boolean isMine = currentUserId != null && currentUserId.equals(author.getUserId()); //작성자 식별
+
                     List<PostCategory> postCategories = postCategoryPort.findAllByPostId(post.getPostId());
                     Category mainCategory = postCategories.isEmpty() ? null : postCategories.get(0).getCategory();
 
@@ -164,7 +168,8 @@ public class FeedService implements FeedGetUseCase {
                                     .map(Photo::getPhotoUrl)
                                     .collect(Collectors.toList()),
                             post.getCreatedAt(),
-                            isLocalReviewFlag  // 여기서 command의 플래그 그대로 사용
+                            isLocalReviewFlag,
+                            isMine
                     );
                 })
                 .collect(Collectors.toList());


### PR DESCRIPTION
### 📝 Work Description
- 탐색 탭에서 표시되는 각 리뷰가 현재 로그인한 사용자의 작성인지 여부를 판별하는 로직을 추가했습니다.

### ⚙️ Issue
[//]: # (연관된 이슈 번호)
- closed #172 

### 🔨 Changes
- FeedFilterCommand에 currentUserId 필드 추가
- 서비스 로직에서 각 게시물의 작성자가 현재 로그인한 사용자와 일치하는지 판별 (isMine 플래그)
- FilteredFeedResponseDTO에 isMine 필드 추가
- API 응답에 isMine 포함되도록 변경

