### PR TITLE
[FEAT] 어드민 시큐리티 설정

### DIFF
--- a/src/main/java/com/spoony/spoony_server/global/auth/annotation/AdminId.java
+++ b/src/main/java/com/spoony/spoony_server/global/auth/annotation/AdminId.java
@@ -1,0 +1,14 @@
+package com.spoony.spoony_server.global.auth.annotation;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression="T(com.spoony.spoony_server.global.auth.jwt.AdminJwtTokenProvider).validatePrincipal(#this)")
+public @interface AdminId {
+}

--- a/src/main/java/com/spoony/spoony_server/global/auth/filter/AdminJwtAuthenticationFilter.java
+++ b/src/main/java/com/spoony/spoony_server/global/auth/filter/AdminJwtAuthenticationFilter.java
@@ -1,0 +1,64 @@
+package com.spoony.spoony_server.global.auth.filter;
+
+import com.spoony.spoony_server.global.auth.constant.AuthConstant;
+import com.spoony.spoony_server.global.auth.jwt.AdminJwtTokenProvider;
+import com.spoony.spoony_server.global.auth.jwt.AdminJwtTokenValidator;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class AdminJwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final AdminJwtTokenProvider adminJwtTokenProvider;
+    private final AdminJwtTokenValidator adminJwtTokenValidator;
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain chain)
+            throws ServletException, IOException {
+
+        String token = resolveToken(request);
+        if (token != null) {
+            adminJwtTokenValidator.validate(token); // 유효성 검증
+            Long adminId = adminJwtTokenProvider.getClaimFromToken(token).userId();
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(adminId, null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AuthConstant.AUTHORIZATION_HEADER);
+        if (bearerToken != null && bearerToken.startsWith(AuthConstant.BEARER_TOKEN_PREFIX)) {
+            return bearerToken.substring(AuthConstant.BEARER_TOKEN_PREFIX.length());
+        }
+        return null;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String requestURI = request.getRequestURI();
+        return !requestURI.startsWith("/api/v1/admin");  // /admin 요청에만 필터 적용
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/global/auth/jwt/AdminJwtTokenValidator.java
+++ b/src/main/java/com/spoony/spoony_server/global/auth/jwt/AdminJwtTokenValidator.java
@@ -1,0 +1,47 @@
+package com.spoony.spoony_server.global.auth.jwt;
+
+import com.spoony.spoony_server.global.auth.dto.ClaimDTO;
+import com.spoony.spoony_server.global.exception.AuthException;
+import com.spoony.spoony_server.global.message.auth.AuthErrorMessage;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AdminJwtTokenValidator {
+
+    private final AdminJwtTokenProvider tokenProvider;
+
+    public void validate(String token) {
+        if (token == null) {
+            throw new AuthException(AuthErrorMessage.EMPTY_TOKEN);
+        }
+
+        try {
+            ClaimDTO claim = tokenProvider.getClaimFromToken(token);
+
+            // 관리자 토큰은 항상 AccessToken이므로 token_type이 true인지 확인
+            if (!claim.isAccessToken()) {
+                throw new AuthException(AuthErrorMessage.INVALID_TOKEN_TYPE);
+            }
+
+            // role이 "ADMIN"인지 Claims에서 직접 검증
+            String role = tokenProvider.getClaims(token).get("role", String.class);
+            if (!"ADMIN".equals(role)) {
+                throw new AuthException(AuthErrorMessage.INVALID_ROLE);
+            }
+
+        } catch (ExpiredJwtException e) {
+            throw new AuthException(AuthErrorMessage.EXPIRED_TOKEN);
+        } catch (UnsupportedJwtException e) {
+            throw new AuthException(AuthErrorMessage.UNSUPPORTED_TOKEN);
+        } catch (MalformedJwtException e) {
+            throw new AuthException(AuthErrorMessage.INVALID_TOKEN);
+        } catch (IllegalArgumentException e) {
+            throw new AuthException(AuthErrorMessage.EMPTY_TOKEN);
+        }
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/spoony/spoony_server/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.spoony.spoony_server.global.config;
 
+import com.spoony.spoony_server.global.auth.filter.AdminJwtAuthenticationFilter;
 import com.spoony.spoony_server.global.auth.filter.JwtAuthenticationFilter;
 import com.spoony.spoony_server.global.auth.filter.JwtExceptionFilter;
 import com.spoony.spoony_server.global.auth.handler.CustomJwtAuthenticationEntryPoint;
@@ -22,6 +23,7 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtExceptionFilter jwtExceptionFilter;
+    private final AdminJwtAuthenticationFilter adminJwtAuthenticationFilter;
     private final CustomJwtAuthenticationEntryPoint authenticationEntryPoint;
 
     private static final List<String> AUTH_WHITE_LIST = List.of(
@@ -30,8 +32,9 @@ public class SecurityConfig {
             "/api/v1/auth/refresh",
             "/api/v1/user/exists",
             "/api/v1/user/region",
+            "/api/v1/admin/auth/login",
+            "/api/v1/admin/auth/signup",
             // TODO: main 브랜치 병합 전 제거 필수 (dev swagger test 인증 토큰 이슈..)
-            "/api/v1/admin/**",
             "/profile-images/**",
             "/swagger-ui/**",
             "/v3/api-docs/**"
@@ -52,6 +55,7 @@ public class SecurityConfig {
                 .anyRequest().authenticated());
 
         http
+                .addFilterBefore(adminJwtAuthenticationFilter, JwtAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class)
                 .exceptionHandling(exceptionHandling ->

--- a/src/main/java/com/spoony/spoony_server/global/message/auth/AuthErrorMessage.java
+++ b/src/main/java/com/spoony/spoony_server/global/message/auth/AuthErrorMessage.java
@@ -25,6 +25,7 @@ public enum AuthErrorMessage implements DefaultErrorMessage {
     UNSUPPORTED_TOKEN(HttpStatus.BAD_REQUEST, "지원하지 않는 토큰 형식입니다."),
     EMPTY_TOKEN(HttpStatus.BAD_REQUEST, "토큰이 비어 있거나 잘못된 요청입니다."),
     UNKNOWN_TOKEN(HttpStatus.UNAUTHORIZED, "알 수 없는 출처의 토큰입니다."),
+    INVALID_ROLE(HttpStatus.FORBIDDEN, "유효하지 않은 관리자 권한입니다."),
 
     // JWT (REFRESH)
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 Refresh 토큰입니다."),


### PR DESCRIPTION
### 📝 Work Description
- 관리자 전용 JWT 인증 구조 구현
- 관리자 로그인, 인증 필터링, ID 주입을 위한 커스텀 어노테이션까지 전체 인증 흐름 설정

### ⚙️ Issue
- #188 

### 🔨 Changes
- JWT 토큰 생성 (`AdminJwtTokenProvider`)
  - `generateToken(adminId)` 메서드로 `accessToken` 발급
  - Claims에 `userId`, `tokenType`, `"role": "ADMIN"` 포함
- 토큰 유효성 검사 (`AdminJwtTokenValidator`)
  - `token == null` 검사 및 JWT 예외 처리
  - 클레임에서 `tokenType == true`, `role == ADMIN` 검증
  - 인증 실패 시 커스텀 `AuthException` 던짐
- 관리자 인증 필터 (`AdminJwtAuthenticationFilter`)
  - `/api/v1/admin/**` 경로에만 필터 적용
  - JWT 검증 후 `SecurityContext`에 `adminId`를 `principal`로 등록
  - `ROLE_ADMIN` 권한 부여
- 커스텀 어노테이션 `@AdminId`
  - `@AuthenticationPrincipal(expression = "...")` 기반
  - `AdminJwtTokenProvider.validatePrincipal()` 통해 비로그인 예외 처리
  - 컨트롤러에서 `@AdminId Long adminId`로 간편하게 주입 가능
- SecurityConfig 설정
  - 관리자 로그인 API는 `permitAll()`로 화이트리스트에 등록
  - `adminJwtAuthenticationFilter` → `jwtAuthenticationFilter` → `jwtExceptionFilter` 순서로 필터 체인 구성

### 🔍 PR Point
- `@AdminId` 어노테이션을 통해 컨트롤러에서 인증 로직 없이 adminId 주입 가능
- 사용자 인증 흐름(`JwtTokenProvider`, `JwtAuthenticationFilter`)과 완전히 분리하여 역할 분리 명확
- 하지만 `JwtTokenProvider`, `JwtAuthenticationFilter` 등과 겹치는 코드가 존재하여 추후 리팩토링 필요

