### PR TITLE
[FEAT] 관리자 로그인 구현

### DIFF
--- a/src/main/java/com/spoony/spoony_server/adapter/auth/dto/request/AdminLoginRequestDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/dto/request/AdminLoginRequestDTO.java
@@ -1,0 +1,3 @@
+package com.spoony.spoony_server.adapter.auth.dto.request;
+
+public record AdminLoginRequestDTO(String email, String password) {}

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/dto/response/AdminLoginResponseDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/dto/response/AdminLoginResponseDTO.java
@@ -1,0 +1,12 @@
+package com.spoony.spoony_server.adapter.auth.dto.response;
+
+public record AdminLoginResponseDTO(
+        Boolean exists,
+        Long adminId,
+        String email,
+        String adminJwtTokenDTO) {
+
+    public static AdminLoginResponseDTO of(Boolean exists, Long adminId, String email, String adminJwtTokenDTO) {
+        return new AdminLoginResponseDTO(exists, adminId, email, adminJwtTokenDTO);
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/in/web/AdminAuthController.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/in/web/AdminAuthController.java
@@ -1,0 +1,30 @@
+package com.spoony.spoony_server.adapter.auth.in.web;
+
+import com.spoony.spoony_server.adapter.auth.dto.request.AdminLoginRequestDTO;
+import com.spoony.spoony_server.adapter.auth.dto.response.AdminLoginResponseDTO;
+import com.spoony.spoony_server.application.auth.port.in.AdminLoginUseCase;
+import com.spoony.spoony_server.global.dto.ResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin")
+public class AdminAuthController {
+
+    private final AdminLoginUseCase adminLoginUseCase;
+
+    @PostMapping("/login")
+    @Operation(summary = "관리자 로그인", description = "관리자로 로그인합니다.")
+    public ResponseEntity<ResponseDTO<AdminLoginResponseDTO>> adminLogin(
+            @RequestBody final AdminLoginRequestDTO adminLoginRequestDTO
+    ) {
+        return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(adminLoginUseCase.login(adminLoginRequestDTO)));
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/admin/AdminPersistenceAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/admin/AdminPersistenceAdapter.java
@@ -1,0 +1,31 @@
+package com.spoony.spoony_server.adapter.out.persistence.admin;
+
+import com.spoony.spoony_server.adapter.out.persistence.admin.db.AdminEntity;
+import com.spoony.spoony_server.adapter.out.persistence.admin.db.AdminRepository;
+import com.spoony.spoony_server.application.auth.port.out.AdminPort;
+import com.spoony.spoony_server.domain.admin.Admin;
+import com.spoony.spoony_server.global.exception.BusinessException;
+import com.spoony.spoony_server.global.message.business.UserErrorMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AdminPersistenceAdapter implements AdminPort {
+
+    private final AdminRepository adminRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public Admin findByEmail(String email) {
+        return adminRepository.findByEmail(email)
+                .map(AdminEntity::toDomain)
+                .orElseThrow(() -> new BusinessException(UserErrorMessage.USER_NOT_FOUND));
+    }
+
+    @Override
+    public boolean checkPassword(String rawPassword, String encodedPassword) {
+        return passwordEncoder.matches(rawPassword, encodedPassword);
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/admin/db/AdminEntity.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/admin/db/AdminEntity.java
@@ -1,0 +1,40 @@
+package com.spoony.spoony_server.adapter.out.persistence.admin.db;
+
+import com.spoony.spoony_server.domain.admin.Admin;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "admin")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class AdminEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long adminId;
+
+    private String email;
+    private String password;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    public static Admin toDomain(AdminEntity adminEntity) {
+        return new Admin(
+                adminEntity.getAdminId(),
+                adminEntity.getEmail(),
+                adminEntity.getPassword()
+        );
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/admin/db/AdminRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/admin/db/AdminRepository.java
@@ -1,0 +1,11 @@
+package com.spoony.spoony_server.adapter.out.persistence.admin.db;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AdminRepository extends JpaRepository<AdminEntity, Long> {
+    Optional<AdminEntity> findByEmail(String email);
+}

--- a/src/main/java/com/spoony/spoony_server/application/auth/port/in/AdminLoginUseCase.java
+++ b/src/main/java/com/spoony/spoony_server/application/auth/port/in/AdminLoginUseCase.java
@@ -1,0 +1,8 @@
+package com.spoony.spoony_server.application.auth.port.in;
+
+import com.spoony.spoony_server.adapter.auth.dto.request.AdminLoginRequestDTO;
+import com.spoony.spoony_server.adapter.auth.dto.response.AdminLoginResponseDTO;
+
+public interface AdminLoginUseCase {
+    AdminLoginResponseDTO login(AdminLoginRequestDTO adminLoginRequestDTO);
+}

--- a/src/main/java/com/spoony/spoony_server/application/auth/port/out/AdminPort.java
+++ b/src/main/java/com/spoony/spoony_server/application/auth/port/out/AdminPort.java
@@ -1,0 +1,8 @@
+package com.spoony.spoony_server.application.auth.port.out;
+
+import com.spoony.spoony_server.domain.admin.Admin;
+
+public interface AdminPort {
+    Admin findByEmail(String email);
+    boolean checkPassword(String rawPassword, String encodedPassword);
+}

--- a/src/main/java/com/spoony/spoony_server/application/auth/service/AdminAuthService.java
+++ b/src/main/java/com/spoony/spoony_server/application/auth/service/AdminAuthService.java
@@ -1,0 +1,37 @@
+package com.spoony.spoony_server.application.auth.service;
+
+import com.spoony.spoony_server.adapter.auth.dto.request.AdminLoginRequestDTO;
+import com.spoony.spoony_server.adapter.auth.dto.response.AdminLoginResponseDTO;
+import com.spoony.spoony_server.application.auth.port.in.AdminLoginUseCase;
+import com.spoony.spoony_server.application.auth.port.out.AdminPort;
+import com.spoony.spoony_server.domain.admin.Admin;
+import com.spoony.spoony_server.global.auth.jwt.AdminJwtTokenProvider;
+import com.spoony.spoony_server.global.exception.AuthException;
+import com.spoony.spoony_server.global.message.auth.AuthErrorMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminAuthService implements AdminLoginUseCase {
+
+    private final AdminPort adminPort;
+    private final AdminJwtTokenProvider adminJwtTokenProvider;
+
+    @Override
+    public AdminLoginResponseDTO login(AdminLoginRequestDTO adminLoginRequestDTO) {
+        Admin admin = adminPort.findByEmail(adminLoginRequestDTO.email());
+        if(admin == null) {
+            return AdminLoginResponseDTO.of(false, null, null, null);
+        }
+
+        boolean valid = adminPort.checkPassword(adminLoginRequestDTO.password(), admin.getPassword());
+        if (!valid) {
+            throw new AuthException(AuthErrorMessage.PASSWORD_NOT_MATCHED);
+        }
+
+        String accessToken = adminJwtTokenProvider.generateToken(admin.getAdminId());
+
+        return AdminLoginResponseDTO.of(true, admin.getAdminId(), admin.getEmail(), accessToken);
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/domain/admin/Admin.java
+++ b/src/main/java/com/spoony/spoony_server/domain/admin/Admin.java
@@ -1,0 +1,12 @@
+package com.spoony.spoony_server.domain.admin;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class Admin {
+    private Long adminId;
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/spoony/spoony_server/global/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/spoony/spoony_server/global/auth/filter/JwtAuthenticationFilter.java
@@ -87,7 +87,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 || requestURI.startsWith("/api/v1/auth/refresh")
                 || requestURI.startsWith("/api/v1/user/exists")
                 || requestURI.startsWith("/api/v1/user/region")
-                || requestURI.startsWith("/api/v1/admin")
+                || requestURI.startsWith("/api/v1/admin/login")
                 || requestURI.startsWith("/profile-images")
                 || requestURI.startsWith("/swagger-ui")
                 || requestURI.startsWith("/v3/api-docs");

--- a/src/main/java/com/spoony/spoony_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/spoony/spoony_server/global/config/SecurityConfig.java
@@ -14,6 +14,9 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.List;
 
@@ -66,5 +69,19 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.addAllowedOriginPattern("*"); // 또는 "http://localhost:3000"
+        config.addAllowedMethod("*");        // GET, POST, PUT, DELETE
+        config.addAllowedHeader("*");
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 }

--- a/src/main/java/com/spoony/spoony_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/spoony/spoony_server/global/config/SecurityConfig.java
@@ -75,8 +75,9 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
 
-        config.addAllowedOriginPattern("*"); // 또는 "http://localhost:3000"
-        config.addAllowedMethod("*");        // GET, POST, PUT, DELETE
+        config.addAllowedOriginPattern("http://localhost:3000");
+        config.addAllowedOriginPattern("https://spoony-admin.vercel.app");
+        config.addAllowedMethod("*");
         config.addAllowedHeader("*");
         config.setAllowCredentials(true);
 

--- a/src/main/java/com/spoony/spoony_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/spoony/spoony_server/global/config/SecurityConfig.java
@@ -10,6 +10,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.RequestCacheConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -30,8 +32,7 @@ public class SecurityConfig {
             "/api/v1/auth/refresh",
             "/api/v1/user/exists",
             "/api/v1/user/region",
-            "/api/v1/admin/auth/login",
-            "/api/v1/admin/auth/signup",
+            "/api/v1/admin/login",
             // TODO: main 브랜치 병합 전 제거 필수 (dev swagger test 인증 토큰 이슈..)
             "/profile-images/**",
             "/swagger-ui/**",
@@ -60,5 +61,10 @@ public class SecurityConfig {
                 );
 
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/spoony/spoony_server/global/message/auth/AuthErrorMessage.java
+++ b/src/main/java/com/spoony/spoony_server/global/message/auth/AuthErrorMessage.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum AuthErrorMessage implements DefaultErrorMessage {
     PLATFORM_NOT_FOUND(HttpStatus.BAD_REQUEST, "유효하지 않은 소셜 플랫폼입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
+    PASSWORD_NOT_MATCHED(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
 
     // APPLE
     INVALID_APPLE_PUBLIC_KEY(HttpStatus.BAD_REQUEST, "유효하지 않은 Apple Public Key입니다."),


### PR DESCRIPTION
### 📝 Work Description
- 관리자 로그인 기능 구현
- 이메일 및 비밀번호 기반 로그인 처리
- 로그인 성공 시 관리자 JWT accessToken 발급 및 응답
- 관리자용 WEB을 위한 CORS 설정 적용

### ⚙️ Issue
[//]: # (연관된 이슈 번호)
- closed #190

### 🔨 Changes
- `AdminLoginRequestDTO`, `AdminLoginResponseDTO` 정의
- `AdminLoginUseCase` 인터페이스 및 구현체(`AdminAuthService`) 작성
- `AdminPort` 및 구현체(`AdminPersistenceAdapter`) 구현
  - 이메일 기반 관리자 조회
  - `PasswordEncoder`를 통한 비밀번호 검증
- 관리자 전용 `AdminJwtTokenProvider`를 통한 토큰 발급 처리
