### PR TITLE
[FEAT] @AdminId 어노테이션을 이용하여 관리자 인증 로직 개선

### DIFF
--- a/src/main/java/com/spoony/spoony_server/adapter/in/web/admin/AdminController.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/in/web/admin/AdminController.java
@@ -26,7 +26,7 @@ public class AdminController {
             @AdminId Long adminId,
             @RequestParam int page,
             @RequestParam int size) {
-        AdminGetAllPostsCommand command = new AdminGetAllPostsCommand(page, size);
+        AdminGetAllPostsCommand command = new AdminGetAllPostsCommand(adminId, page, size);
         AdminPostListResponseDTO result = adminPostUseCase.getAllPosts(command);
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(result));
     }
@@ -37,7 +37,7 @@ public class AdminController {
             @AdminId Long adminId,
             @RequestParam int page,
             @RequestParam int size) {
-        AdminGetReportedPostsCommand command = new AdminGetReportedPostsCommand(page, size);
+        AdminGetReportedPostsCommand command = new AdminGetReportedPostsCommand(adminId, page, size);
         ReportedPostListResponseDTO result = adminPostUseCase.getReportedPosts(command);
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(result));
     }
@@ -49,7 +49,7 @@ public class AdminController {
             @RequestParam int page,
             @RequestParam int size,
             @RequestParam(defaultValue = "1") int reportCount) {
-        AdminGetReportedUsersCommand command = new AdminGetReportedUsersCommand(page, size, reportCount);
+        AdminGetReportedUsersCommand command = new AdminGetReportedUsersCommand(adminId, page, size, reportCount);
         ReportedUserListResponseDTO result = adminUserUseCase.getReportedUsers(command);
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(result));
     }
@@ -61,7 +61,7 @@ public class AdminController {
             @PathVariable Long userId,
             @RequestParam int page,
             @RequestParam int size) {
-        AdminGetUserPostsCommand command = new AdminGetUserPostsCommand(userId, page, size);
+        AdminGetUserPostsCommand command = new AdminGetUserPostsCommand(adminId, userId, page, size);
         UserPostListResponseDTO result = adminPostUseCase.getPostsByUser(command);
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(result));
     }
@@ -71,7 +71,7 @@ public class AdminController {
     public ResponseEntity<ResponseDTO<Void>> deletePost(
             @AdminId Long adminId,
             @PathVariable Long postId) {
-        adminPostUseCase.deletePost(new AdminDeletePostCommand(postId));
+        adminPostUseCase.deletePost(new AdminDeletePostCommand(adminId, postId));
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(null));
     }
 
@@ -80,7 +80,7 @@ public class AdminController {
     public ResponseEntity<ResponseDTO<Void>> deleteUser(
             @AdminId Long adminId,
             @PathVariable Long userId) {
-        adminUserUseCase.deleteUser(new AdminDeleteUserCommand(userId));
+        adminUserUseCase.deleteUser(new AdminDeleteUserCommand(adminId, userId));
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(null));
     }
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/admin/AdminPersistenceAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/admin/AdminPersistenceAdapter.java
@@ -4,8 +4,8 @@ import com.spoony.spoony_server.adapter.out.persistence.admin.db.AdminEntity;
 import com.spoony.spoony_server.adapter.out.persistence.admin.db.AdminRepository;
 import com.spoony.spoony_server.application.auth.port.out.AdminPort;
 import com.spoony.spoony_server.domain.admin.Admin;
-import com.spoony.spoony_server.global.exception.BusinessException;
-import com.spoony.spoony_server.global.message.business.UserErrorMessage;
+import com.spoony.spoony_server.global.exception.AuthException;
+import com.spoony.spoony_server.global.message.auth.AuthErrorMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Repository;
@@ -18,10 +18,17 @@ public class AdminPersistenceAdapter implements AdminPort {
     private final PasswordEncoder passwordEncoder;
 
     @Override
+    public Admin findByAdminId(Long adminId) {
+        return adminRepository.findById(adminId)
+                .map(AdminEntity::toDomain)
+                .orElseThrow(() -> new AuthException(AuthErrorMessage.ADMIN_NOT_FOUND));
+    }
+
+    @Override
     public Admin findByEmail(String email) {
         return adminRepository.findByEmail(email)
                 .map(AdminEntity::toDomain)
-                .orElseThrow(() -> new BusinessException(UserErrorMessage.USER_NOT_FOUND));
+                .orElseThrow(() -> new AuthException(AuthErrorMessage.ADMIN_NOT_FOUND));
     }
 
     @Override

--- a/src/main/java/com/spoony/spoony_server/application/auth/port/out/AdminPort.java
+++ b/src/main/java/com/spoony/spoony_server/application/auth/port/out/AdminPort.java
@@ -4,5 +4,6 @@ import com.spoony.spoony_server.domain.admin.Admin;
 
 public interface AdminPort {
     Admin findByEmail(String email);
+    Admin findByAdminId(Long adminId);
     boolean checkPassword(String rawPassword, String encodedPassword);
 }

--- a/src/main/java/com/spoony/spoony_server/application/port/command/admin/AdminDeletePostCommand.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/command/admin/AdminDeletePostCommand.java
@@ -6,5 +6,6 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public class AdminDeletePostCommand {
+    private final Long adminId;
     private final Long postId;
 }

--- a/src/main/java/com/spoony/spoony_server/application/port/command/admin/AdminDeleteUserCommand.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/command/admin/AdminDeleteUserCommand.java
@@ -6,5 +6,6 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public class AdminDeleteUserCommand {
+    private final Long adminId;
     private final Long userId;
 }

--- a/src/main/java/com/spoony/spoony_server/application/port/command/admin/AdminGetAllPostsCommand.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/command/admin/AdminGetAllPostsCommand.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public class AdminGetAllPostsCommand {
+    private final Long adminId;
     private final int page;
     private final int size;
 }

--- a/src/main/java/com/spoony/spoony_server/application/port/command/admin/AdminGetReportedPostsCommand.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/command/admin/AdminGetReportedPostsCommand.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public class AdminGetReportedPostsCommand {
+    private final Long adminId;
     private final int page;
     private final int size;
 }

--- a/src/main/java/com/spoony/spoony_server/application/port/command/admin/AdminGetReportedUsersCommand.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/command/admin/AdminGetReportedUsersCommand.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public class AdminGetReportedUsersCommand {
+    private final Long adminId;
     private final int page;
     private final int size;
     private final int reportCount;

--- a/src/main/java/com/spoony/spoony_server/application/port/command/admin/AdminGetUserPostsCommand.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/command/admin/AdminGetUserPostsCommand.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public class AdminGetUserPostsCommand {
+    private final Long adminId;
     private final Long userId;
     private final int page;
     private final int size;

--- a/src/main/java/com/spoony/spoony_server/application/service/admin/AdminService.java
+++ b/src/main/java/com/spoony/spoony_server/application/service/admin/AdminService.java
@@ -2,11 +2,13 @@ package com.spoony.spoony_server.application.service.admin;
 
 import com.spoony.spoony_server.adapter.dto.Pagination;
 import com.spoony.spoony_server.adapter.dto.admin.response.*;
+import com.spoony.spoony_server.application.auth.port.out.AdminPort;
 import com.spoony.spoony_server.application.port.command.admin.*;
 import com.spoony.spoony_server.application.port.in.admin.*;
 import com.spoony.spoony_server.application.port.out.post.PostPort;
 import com.spoony.spoony_server.application.port.out.report.ReportPort;
 import com.spoony.spoony_server.application.port.out.user.UserPort;
+import com.spoony.spoony_server.domain.admin.Admin;
 import com.spoony.spoony_server.domain.place.Place;
 import com.spoony.spoony_server.domain.post.Menu;
 import com.spoony.spoony_server.domain.post.Photo;
@@ -30,9 +32,12 @@ public class AdminService implements AdminPostUseCase, AdminUserUseCase {
     private final PostPort postPort;
     private final ReportPort reportPort;
     private final UserPort userPort;
+    private final AdminPort adminPort;
 
     @Override
     public AdminPostListResponseDTO getAllPosts(AdminGetAllPostsCommand command) {
+        // admin 존재 여부 확인
+        Admin admin = adminPort.findByAdminId(command.getAdminId());
 
         int page = command.getPage();
         int size = command.getSize();
@@ -110,6 +115,9 @@ public class AdminService implements AdminPostUseCase, AdminUserUseCase {
 
     @Override
     public ReportedPostListResponseDTO getReportedPosts(AdminGetReportedPostsCommand command) {
+        // admin 존재 여부 확인
+        Admin admin = adminPort.findByAdminId(command.getAdminId());
+
         int page = command.getPage();
         int size = command.getSize();
 
@@ -185,6 +193,9 @@ public class AdminService implements AdminPostUseCase, AdminUserUseCase {
 
     @Override
     public ReportedUserListResponseDTO getReportedUsers(AdminGetReportedUsersCommand command) {
+        // admin 존재 여부 확인
+        Admin admin = adminPort.findByAdminId(command.getAdminId());
+
         int page = command.getPage();
         int size = command.getSize();
 
@@ -231,6 +242,9 @@ public class AdminService implements AdminPostUseCase, AdminUserUseCase {
 
     @Override
     public UserPostListResponseDTO getPostsByUser(AdminGetUserPostsCommand command) {
+        // admin 존재 여부 확인
+        Admin admin = adminPort.findByAdminId(command.getAdminId());
+
         Long userId = command.getUserId();
         int page = command.getPage();
         int size = command.getSize();
@@ -318,12 +332,18 @@ public class AdminService implements AdminPostUseCase, AdminUserUseCase {
 
     @Override
     public void deletePost(AdminDeletePostCommand command) {
+        // admin 존재 여부 확인
+        Admin admin = adminPort.findByAdminId(command.getAdminId());
+
         Long postId = command.getPostId();
         postPort.deleteById(postId);
     }
 
     @Override
     public void deleteUser(AdminDeleteUserCommand command) {
+        // admin 존재 여부 확인
+        Admin admin = adminPort.findByAdminId(command.getAdminId());
+
         Long userId = command.getUserId();
         userPort.deleteUser(userId);
     }

--- a/src/main/java/com/spoony/spoony_server/global/message/auth/AuthErrorMessage.java
+++ b/src/main/java/com/spoony/spoony_server/global/message/auth/AuthErrorMessage.java
@@ -11,6 +11,7 @@ public enum AuthErrorMessage implements DefaultErrorMessage {
     PLATFORM_NOT_FOUND(HttpStatus.BAD_REQUEST, "유효하지 않은 소셜 플랫폼입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
     PASSWORD_NOT_MATCHED(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
+    ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 관리자입니다."),
 
     // APPLE
     INVALID_APPLE_PUBLIC_KEY(HttpStatus.BAD_REQUEST, "유효하지 않은 Apple Public Key입니다."),


### PR DESCRIPTION
### 📝 Work Description
- 컨트롤러에서 관리자의 `adminId`를 주입받고, 서비스 레이어에서 엔티티 존재 여부를 검증하는 이중 인증 구조로 변경  

### ⚙️ Issue  
- closed #195  

### 🔨 Changes  
- AdminController 내 6개 API 메서드에 `@AdminId` 적용  
  - 전체 게시글 조회
  - 신고된 게시글 조회
  - 신고된 유저 목록 조회
  - 유저별 게시글 조회
  - 게시글 삭제
  - 유저 삭제  
- AdminUseCase 서비스 계층에서 `adminPort.findByAdminId(adminId)` 호출로 실제 존재하는 관리자 검증  

### 🔍 PR Point  
- AdminPort를 통해 관리자 존재 여부를 확인함으로써 토큰만으로 인증을 우회할 수 없도록 보안 강화  