### PR TITLE
[FEAT] isDeleted가 false인 리뷰만 조회

### DIFF
--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/feed/FeedPersistenceAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/feed/FeedPersistenceAdapter.java
@@ -24,7 +24,7 @@ public class FeedPersistenceAdapter implements FeedPort {
 
     @Override
     public List<Feed> findFeedListByFollowing(Long userId) {
-        return feedRepository.findByUser_UserId(userId)
+        return feedRepository.findByUser_UserIdAndPost_DeletedFalse(userId)
                 .stream()
                 .map(FeedMapper::toDomain)
                 .toList();

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/feed/db/FeedRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/feed/db/FeedRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface FeedRepository extends JpaRepository<FeedEntity, Long>, JpaSpecificationExecutor<FeedEntity> {
-    List<FeedEntity> findByUser_UserId(Long userId);
+    List<FeedEntity> findByUser_UserIdAndPost_DeletedFalse(Long userId);
     void deleteByUser_UserIdAndPost_PostId(Long userId, Long postId);
     void deleteByUser_UserIdAndAuthor_UserId(Long userId, Long authorId);
     @Query("SELECT f.post.postId FROM FeedEntity f WHERE f.user.userId = :userId AND f.post.postId IN :postIds")

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/PostPersistenceAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/PostPersistenceAdapter.java
@@ -53,7 +53,7 @@ public class PostPersistenceAdapter implements
 
     @Override
     public List<Post> findPostsByUserId(Long userId) {
-        return postRepository.findByUser_UserId(userId)
+        return postRepository.findByUser_UserIdAndDeletedFalse(userId)
                 .stream()
                 .map(PostMapper::toDomain)
                 .collect(Collectors.toList());

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/PostPersistenceAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/PostPersistenceAdapter.java
@@ -288,7 +288,8 @@ public class PostPersistenceAdapter implements
 
     @Override
     public Long countPostsByUserIdExcludingReported(Long userId,List <Long> reportedPostIds) {
-        return postRepository.countByUser_UserId(userId,reportedPostIds);
+        List<Long> ids = (reportedPostIds == null || reportedPostIds.isEmpty()) ? null : reportedPostIds;
+        return postRepository.countByUser_UserId(userId, ids);
     }
 
     @Override

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/PostPersistenceAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/PostPersistenceAdapter.java
@@ -235,7 +235,7 @@ public class PostPersistenceAdapter implements
 
     @Override
     public List<Post> findByPostDescriptionContaining(String query) {
-        List<PostEntity> postEntityList = postRepository.findByDescriptionContaining(query);
+        List<PostEntity> postEntityList = postRepository.findByDescriptionContainingAndDeletedFalse(query);
         return postEntityList.stream().map(PostMapper::toDomain).collect(Collectors.toList());
     }
 

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostRepository.java
@@ -15,7 +15,7 @@ public interface PostRepository extends JpaRepository<PostEntity, Long> , JpaSpe
 
     List<PostEntity> findByUser_UserIdAndDeletedFalse(Long userId);
     List<PostEntity> findByUser_UserId(Long userId);
-    @Query("SELECT COUNT(p) FROM PostEntity p WHERE p.user.userId = :userId AND (:reportedPostIds IS NULL OR p.postId NOT IN :reportedPostIds)")
+    @Query("SELECT COUNT(p) FROM PostEntity p WHERE p.user.userId = :userId AND p.isDeleted = false AND (:reportedPostIds IS NULL OR p.postId NOT IN :reportedPostIds)")
     Long countByUser_UserId(@Param("userId") Long userId,
                             @Param("reportedPostIds") List<Long> reportedPostIds);
 

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostRepository.java
@@ -13,6 +13,7 @@ import java.util.List;
 @Repository
 public interface PostRepository extends JpaRepository<PostEntity, Long> , JpaSpecificationExecutor<PostEntity> {
 
+    List<PostEntity> findByUser_UserIdAndDeletedFalse(Long userId);
     List<PostEntity> findByUser_UserId(Long userId);
     @Query("SELECT COUNT(p) FROM PostEntity p WHERE p.user.userId = :userId AND (:reportedPostIds IS NULL OR p.postId NOT IN :reportedPostIds)")
     Long countByUser_UserId(@Param("userId") Long userId,

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostRepository.java
@@ -21,7 +21,7 @@ public interface PostRepository extends JpaRepository<PostEntity, Long> , JpaSpe
 
 
     //Long countByUser_UserId(Long userId);
-    List<PostEntity> findByDescriptionContaining(String query);
+    List<PostEntity> findByDescriptionContainingAndDeletedFalse(String query);
 
     @Query("SELECT r.post.postId  FROM ReportEntity r WHERE r.user.userId = :userId")
     List<Long> findReportedPostIdsByUserId(@Param("userId") Long userId);

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/zzim/ZzimPostSpecification.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/zzim/ZzimPostSpecification.java
@@ -11,21 +11,32 @@ public class ZzimPostSpecification {
 
     public static Specification<ZzimPostEntity> withUserIdAndCategoryId(Long userId, Long categoryId){
         return (root, query, cb) -> {
+            Join<ZzimPostEntity, PostEntity> postJoin = root.join("post");
+
+            Predicate notDeleted = cb.isFalse(postJoin.get("isDeleted"));
+
             if (categoryId != null && categoryId == 1L) {
-                return cb.equal(root.get("user").get("userId"), userId);
+                Predicate userPredicate = cb.equal(root.get("user").get("userId"), userId);
+                return cb.and(userPredicate, notDeleted);
             } else {
-                Join<ZzimPostEntity, PostEntity> postJoin = root.join("post");
                 Join<PostEntity, PostCategoryEntity> pcJoin = postJoin.join("postCategories");
 
                 Predicate userPredicate = cb.equal(root.get("user").get("userId"), userId);
                 Predicate categoryPredicate = cb.equal(pcJoin.get("category").get("categoryId"), categoryId);
 
-                return cb.and(userPredicate, categoryPredicate);
+                return cb.and(userPredicate, categoryPredicate, notDeleted);
             }
         };
     }
 
     public static Specification<ZzimPostEntity> withUserId(Long userId) {
-        return (root, query, cb) -> cb.equal(root.get("user").get("userId"), userId);
+        return (root, query, cb) -> {
+            Join<ZzimPostEntity, PostEntity> postJoin = root.join("post");
+
+            Predicate userPredicate = cb.equal(root.get("user").get("userId"), userId);
+            Predicate notDeleted = cb.isFalse(postJoin.get("isDeleted"));
+
+            return cb.and(userPredicate, notDeleted);
+        };
     }
 }


### PR DESCRIPTION
### 📝 Work Description
게시글 엔티티에 논리적 삭제(soft delete) 플래그 `is_deleted`를 도입하고, 게시물 조회/검색/피드/북마크 등 전체 조회 로직에서 `is_deleted = false`인 데이터만 반환하도록 수정.

### ⚙️ Issue
- closed #200

### 🔨 Changes
- `PostEntity`에 `isDeleted` 플래그 기반 필터링 적용
- Repository 계층에서 `is_deleted = false` 조건이 항상 반영되도록 메서드 수정
- 이미 북마크/피드에 등록된 항목이 삭제된 경우, 조회/집계에서 제외되도록 처리
- 관련 API들의 목록/검색/피드/북마크 조회 시 삭제된 게시물 제외

### 🔍 PR Point
- 모든 조회 로직에서 `is_deleted` 조건이 빠짐없이 적용되었는지 확인 필요

### 💡 Feature Description
`is_deleted` 플래그를 기반으로 한 논리 삭제 처리 로직을 도입하여  
아래 API 호출 시 삭제된 게시물이 집계/결과에 포함되지 않도록 함.