### PR TITLE
[FEAT] isDeleted가 false인 리뷰만 조회

### DIFF
--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/feed/FeedPersistenceAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/feed/FeedPersistenceAdapter.java
@@ -24,7 +24,7 @@ public class FeedPersistenceAdapter implements FeedPort {
 
     @Override
     public List<Feed> findFeedListByFollowing(Long userId) {
-        return feedRepository.findByUser_UserId(userId)
+        return feedRepository.findByUser_UserIdAndPost_IsDeletedFalse(userId)
                 .stream()
                 .map(FeedMapper::toDomain)
                 .toList();

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/feed/db/FeedRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/feed/db/FeedRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface FeedRepository extends JpaRepository<FeedEntity, Long>, JpaSpecificationExecutor<FeedEntity> {
-    List<FeedEntity> findByUser_UserId(Long userId);
+    List<FeedEntity> findByUser_UserIdAndPost_IsDeletedFalse(Long userId);
     void deleteByUser_UserIdAndPost_PostId(Long userId, Long postId);
     void deleteByUser_UserIdAndAuthor_UserId(Long userId, Long authorId);
     @Query("SELECT f.post.postId FROM FeedEntity f WHERE f.user.userId = :userId AND f.post.postId IN :postIds")

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostEntity.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostEntity.java
@@ -10,6 +10,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -23,6 +24,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "post")
+@SQLRestriction("is_deleted = false")
 public class PostEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/zzim/ZzimPostSpecification.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/zzim/ZzimPostSpecification.java
@@ -11,21 +11,32 @@ public class ZzimPostSpecification {
 
     public static Specification<ZzimPostEntity> withUserIdAndCategoryId(Long userId, Long categoryId){
         return (root, query, cb) -> {
+            Join<ZzimPostEntity, PostEntity> postJoin = root.join("post");
+
+            Predicate notDeleted = cb.isFalse(postJoin.get("isDeleted"));
+
             if (categoryId != null && categoryId == 1L) {
-                return cb.equal(root.get("user").get("userId"), userId);
+                Predicate userPredicate = cb.equal(root.get("user").get("userId"), userId);
+                return cb.and(userPredicate, notDeleted);
             } else {
-                Join<ZzimPostEntity, PostEntity> postJoin = root.join("post");
                 Join<PostEntity, PostCategoryEntity> pcJoin = postJoin.join("postCategories");
 
                 Predicate userPredicate = cb.equal(root.get("user").get("userId"), userId);
                 Predicate categoryPredicate = cb.equal(pcJoin.get("category").get("categoryId"), categoryId);
 
-                return cb.and(userPredicate, categoryPredicate);
+                return cb.and(userPredicate, categoryPredicate, notDeleted);
             }
         };
     }
 
     public static Specification<ZzimPostEntity> withUserId(Long userId) {
-        return (root, query, cb) -> cb.equal(root.get("user").get("userId"), userId);
+        return (root, query, cb) -> {
+            Join<ZzimPostEntity, PostEntity> postJoin = root.join("post");
+
+            Predicate userPredicate = cb.equal(root.get("user").get("userId"), userId);
+            Predicate notDeleted = cb.isFalse(postJoin.get("isDeleted"));
+
+            return cb.and(userPredicate, notDeleted);
+        };
     }
 }


### PR DESCRIPTION
### 📝 Work Description
- 마이페이지 조회, 찜한 리뷰 조회 등 리뷰를 조회하는 모든 경우에 `isDeleted = false` 조건을 적용하여 논리적 삭제(Soft Delete) 를 반영
- `ZzimPostSpecification` 에서 `post.isDeleted = false` 조건을 추가하여, 삭제된 리뷰는 조회되지 않도록 변경

### ⚙️ Issue
- closed #200 

### 🔨 Changes
- `PostEntity` 에 `@SQLRestriction("is_deleted = false")` 추가  
- `ZzimPostSpecification.withUserIdAndCategoryId` → `post.isDeleted = false` 조건 추가
- `ZzimPostSpecification.withUserId` → `post.isDeleted = false` 조건 추가

### 🔍 PR Point
- 기존에 조회되던 리뷰 수가 줄어들 수 있음 (삭제된 데이터 제외 효과)  
- 추후 `@SQLDelete` 와 함께 사용하면, 물리적 삭제 대신 `isDeleted` 업데이트만으로도 안전하게 Soft Delete 유지 가능