### PR TITLE
[FEAT] 어드민 API 논리적 삭제 적용

### DIFF
--- a/src/main/java/com/spoony/spoony_server/adapter/dto/admin/response/AdminPostResponseDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/dto/admin/response/AdminPostResponseDTO.java
@@ -17,7 +17,8 @@ public record AdminPostResponseDTO(String postId,
                                    LocalDateTime updatedAt,
                                    boolean isReported,
                                    int reportCount,
-                                   List<ReportDTO> reports) {
+                                   List<ReportDTO> reports,
+                                   LocalDateTime deletedAt) {
 
     public static AdminPostResponseDTO of(String postId,
                                           String authorId,
@@ -32,8 +33,9 @@ public record AdminPostResponseDTO(String postId,
                                           LocalDateTime updatedAt,
                                           boolean isReported,
                                           int reportCount,
-                                          List<ReportDTO> reports) {
-        return new AdminPostResponseDTO(postId, authorId, authorName, content, restaurantName, disappointment, imageUrls, location, menus, createdAt, updatedAt, isReported, reportCount, reports);
+                                          List<ReportDTO> reports,
+                                          LocalDateTime deletedAt) {
+        return new AdminPostResponseDTO(postId, authorId, authorName, content, restaurantName, disappointment, imageUrls, location, menus, createdAt, updatedAt, isReported, reportCount, reports, deletedAt);
     }
 
     public record MenuDTO(String id, String name) {

--- a/src/main/java/com/spoony/spoony_server/adapter/dto/admin/response/DeletedPostListResponseDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/dto/admin/response/DeletedPostListResponseDTO.java
@@ -1,0 +1,14 @@
+package com.spoony.spoony_server.adapter.dto.admin.response;
+
+import com.spoony.spoony_server.adapter.dto.Pagination;
+
+import java.util.List;
+
+public record DeletedPostListResponseDTO(List<AdminPostResponseDTO> posts,
+                                         Pagination pagination) {
+    public static DeletedPostListResponseDTO of(
+            List<AdminPostResponseDTO> posts,
+            Pagination pagination) {
+        return new DeletedPostListResponseDTO(posts, pagination);
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/in/web/admin/AdminController.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/in/web/admin/AdminController.java
@@ -83,4 +83,33 @@ public class AdminController {
         adminUserUseCase.deleteUser(new AdminDeleteUserCommand(adminId, userId));
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(null));
     }
+
+    @PostMapping("/posts/delete/{postId}")
+    @Operation(summary = "게시글 소프트 삭제", description = "지정된 게시글을 소프트 삭제합니다. (isDeleted = true, deletedAt 기록)")
+    public ResponseEntity<ResponseDTO<Void>> softDeletePost(
+            @AdminId Long adminId,
+            @PathVariable Long postId) {
+        adminPostUseCase.softDeletePost(new AdminSoftDeletePostCommand(adminId, postId));
+        return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(null));
+    }
+
+    @GetMapping("/posts/deleted")
+    @Operation(summary = "삭제된 게시글 목록 조회", description = "소프트 삭제된 게시글들을 페이징으로 조회합니다.")
+    public ResponseEntity<ResponseDTO<DeletedPostListResponseDTO>> getDeletedPosts(
+            @AdminId Long adminId,
+            @RequestParam int page,
+            @RequestParam int size) {
+        AdminGetDeletedPostsCommand command = new AdminGetDeletedPostsCommand(adminId, page, size);
+        DeletedPostListResponseDTO result = adminPostUseCase.getDeletedPosts(command);
+        return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(result));
+    }
+
+    @PostMapping("/posts/restore/{postId}")
+    @Operation(summary = "삭제된 게시글 복구", description = "소프트 삭제된 게시글을 복구합니다. (isDeleted = false, deletedAt = null)")
+    public ResponseEntity<ResponseDTO<Void>> restorePost(
+            @AdminId Long adminId,
+            @PathVariable Long postId) {
+        adminPostUseCase.restorePost(new AdminRestorePostCommand(adminId, postId));
+        return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(null));
+    }
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/admin/AdminPostPersistenceAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/admin/AdminPostPersistenceAdapter.java
@@ -1,0 +1,54 @@
+package com.spoony.spoony_server.adapter.out.persistence.admin;
+
+import com.spoony.spoony_server.adapter.out.persistence.post.db.PostEntity;
+import com.spoony.spoony_server.adapter.out.persistence.post.db.PostRepository;
+import com.spoony.spoony_server.adapter.out.persistence.post.mapper.PostMapper;
+import com.spoony.spoony_server.application.port.out.admin.AdminPostPort;
+import com.spoony.spoony_server.domain.post.Post;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class AdminPostPersistenceAdapter implements AdminPostPort {
+
+    private final PostRepository postRepository;
+
+    @Override
+    @Transactional
+    public void softDelete(Long postId) {
+        PostEntity entity = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("Post not found: " + postId));
+        entity.markDeleted();
+        postRepository.save(entity);
+    }
+
+    @Override
+    @Transactional
+    public void restore(Long postId) {
+        PostEntity entity = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("Post not found: " + postId));
+        entity.restore();
+        postRepository.save(entity);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Post> findDeleted(int page, int size) {
+        PageRequest pageable = PageRequest.of(page - 1, size);
+        return postRepository.findDeletedPosts(pageable)
+                .stream()
+                .map(PostMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public int countDeletedPosts() {
+        return (int) postRepository.countDeletedPosts();
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostEntity.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostEntity.java
@@ -102,4 +102,16 @@ public class PostEntity {
             this.zzimCount += delta;
         }
     }
+
+    // 논리적 삭제
+    public void markDeleted() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    // 논리적 삭제 복구
+    public void restore() {
+        this.isDeleted = false;
+        this.deletedAt = null;
+    }
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostRepository.java
@@ -1,6 +1,5 @@
 package com.spoony.spoony_server.adapter.out.persistence.post.db;
 
-import com.spoony.spoony_server.adapter.out.persistence.user.db.UserEntity;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -36,4 +35,13 @@ public interface PostRepository extends JpaRepository<PostEntity, Long> , JpaSpe
 
     @Query("SELECT COUNT(p) FROM PostEntity p WHERE p.user.userId = :userId")
     int countByUserId(@Param("userId") Long userId);
+
+    @Query(
+            value = "SELECT * FROM post WHERE is_deleted = true ORDER BY created_at DESC",
+            nativeQuery = true
+    )
+    List<PostEntity> findDeletedPosts(Pageable pageable);
+
+    @Query(value = "SELECT COUNT(*) FROM post WHERE is_deleted = true", nativeQuery = true)
+    long countDeletedPosts();
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/mapper/PostMapper.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/mapper/PostMapper.java
@@ -43,7 +43,9 @@ public class PostMapper {
                 postEntity.getCons(),
                 postEntity.getZzimCount(),
                 postEntity.getCreatedAt(),
-                postEntity.getUpdatedAt()
+                postEntity.getUpdatedAt(),
+                postEntity.isDeleted(),
+                postEntity.getDeletedAt()
         );
     }
     public static PostEntity toEntity(Post post) {

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/zzim/mapper/ZzimMapper.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/zzim/mapper/ZzimMapper.java
@@ -38,7 +38,9 @@ public class ZzimMapper {
                         zzimPostEntity.getPost().getCons(),
                         zzimPostEntity.getPost().getZzimCount(),
                         zzimPostEntity.getPost().getCreatedAt(),
-                        zzimPostEntity.getPost().getUpdatedAt()
+                        zzimPostEntity.getPost().getUpdatedAt(),
+                        zzimPostEntity.getPost().isDeleted(),
+                        zzimPostEntity.getPost().getDeletedAt()
                 )
         );
     }

--- a/src/main/java/com/spoony/spoony_server/application/port/command/admin/AdminGetDeletedPostsCommand.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/command/admin/AdminGetDeletedPostsCommand.java
@@ -1,0 +1,12 @@
+package com.spoony.spoony_server.application.port.command.admin;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class AdminGetDeletedPostsCommand {
+    private final Long adminId;
+    private final int page;
+    private final int size;
+}

--- a/src/main/java/com/spoony/spoony_server/application/port/command/admin/AdminRestorePostCommand.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/command/admin/AdminRestorePostCommand.java
@@ -1,0 +1,11 @@
+package com.spoony.spoony_server.application.port.command.admin;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class AdminRestorePostCommand {
+    private final Long adminId;
+    private final Long postId;
+}

--- a/src/main/java/com/spoony/spoony_server/application/port/command/admin/AdminSoftDeletePostCommand.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/command/admin/AdminSoftDeletePostCommand.java
@@ -1,0 +1,11 @@
+package com.spoony.spoony_server.application.port.command.admin;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class AdminSoftDeletePostCommand {
+    private final Long adminId;
+    private final Long postId;
+}

--- a/src/main/java/com/spoony/spoony_server/application/port/in/admin/AdminPostUseCase.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/in/admin/AdminPostUseCase.java
@@ -1,12 +1,10 @@
 package com.spoony.spoony_server.application.port.in.admin;
 
 import com.spoony.spoony_server.adapter.dto.admin.response.AdminPostListResponseDTO;
+import com.spoony.spoony_server.adapter.dto.admin.response.DeletedPostListResponseDTO;
 import com.spoony.spoony_server.adapter.dto.admin.response.ReportedPostListResponseDTO;
 import com.spoony.spoony_server.adapter.dto.admin.response.UserPostListResponseDTO;
-import com.spoony.spoony_server.application.port.command.admin.AdminDeletePostCommand;
-import com.spoony.spoony_server.application.port.command.admin.AdminGetAllPostsCommand;
-import com.spoony.spoony_server.application.port.command.admin.AdminGetReportedPostsCommand;
-import com.spoony.spoony_server.application.port.command.admin.AdminGetUserPostsCommand;
+import com.spoony.spoony_server.application.port.command.admin.*;
 
 public interface AdminPostUseCase {
     ReportedPostListResponseDTO getReportedPosts(AdminGetReportedPostsCommand command);
@@ -16,4 +14,10 @@ public interface AdminPostUseCase {
     void deletePost(AdminDeletePostCommand adminDeletePostCommand);
 
     AdminPostListResponseDTO getAllPosts(AdminGetAllPostsCommand command);
+
+    void softDeletePost(AdminSoftDeletePostCommand command);
+
+    DeletedPostListResponseDTO getDeletedPosts(AdminGetDeletedPostsCommand command);
+
+    void restorePost(AdminRestorePostCommand command);
 }

--- a/src/main/java/com/spoony/spoony_server/application/port/out/admin/AdminPostPort.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/out/admin/AdminPostPort.java
@@ -1,0 +1,12 @@
+package com.spoony.spoony_server.application.port.out.admin;
+
+import com.spoony.spoony_server.domain.post.Post;
+
+import java.util.List;
+
+public interface AdminPostPort {
+    void softDelete(Long postId);   // 논리 삭제
+    void restore(Long postId);      // 복구
+    List<Post> findDeleted(int page, int size); // 삭제된 게시글 조회
+    int countDeletedPosts();
+}

--- a/src/main/java/com/spoony/spoony_server/application/service/admin/AdminService.java
+++ b/src/main/java/com/spoony/spoony_server/application/service/admin/AdminService.java
@@ -347,4 +347,19 @@ public class AdminService implements AdminPostUseCase, AdminUserUseCase {
         Long userId = command.getUserId();
         userPort.deleteUser(userId);
     }
+
+    @Override
+    public void softDeletePost(AdminSoftDeletePostCommand command) {
+
+    }
+
+    @Override
+    public DeletedPostListResponseDTO getDeletedPosts(AdminGetDeletedPostsCommand command) {
+        return null;
+    }
+
+    @Override
+    public void restorePost(AdminRestorePostCommand command) {
+
+    }
 }

--- a/src/main/java/com/spoony/spoony_server/application/service/admin/AdminService.java
+++ b/src/main/java/com/spoony/spoony_server/application/service/admin/AdminService.java
@@ -5,6 +5,7 @@ import com.spoony.spoony_server.adapter.dto.admin.response.*;
 import com.spoony.spoony_server.application.auth.port.out.AdminPort;
 import com.spoony.spoony_server.application.port.command.admin.*;
 import com.spoony.spoony_server.application.port.in.admin.*;
+import com.spoony.spoony_server.application.port.out.admin.AdminPostPort;
 import com.spoony.spoony_server.application.port.out.post.PostPort;
 import com.spoony.spoony_server.application.port.out.report.ReportPort;
 import com.spoony.spoony_server.application.port.out.user.UserPort;
@@ -19,6 +20,7 @@ import com.spoony.spoony_server.domain.user.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -33,6 +35,7 @@ public class AdminService implements AdminPostUseCase, AdminUserUseCase {
     private final ReportPort reportPort;
     private final UserPort userPort;
     private final AdminPort adminPort;
+    private final AdminPostPort adminPostPort;
 
     @Override
     public AdminPostListResponseDTO getAllPosts(AdminGetAllPostsCommand command) {
@@ -104,7 +107,8 @@ public class AdminService implements AdminPostUseCase, AdminUserUseCase {
                             post.getUpdatedAt(),
                             isReported,
                             reportCount,
-                            reportDTOs
+                            reportDTOs,
+                            null
                     );
                 })
                 .toList();
@@ -182,7 +186,8 @@ public class AdminService implements AdminPostUseCase, AdminUserUseCase {
                             post.getUpdatedAt(),
                             true,
                             reportCount,
-                            reportDTOs
+                            reportDTOs,
+                            null
                     );
                 })
                 .toList();
@@ -311,7 +316,8 @@ public class AdminService implements AdminPostUseCase, AdminUserUseCase {
                             post.getUpdatedAt(),
                             isReported,
                             reportCount,
-                            reportDTOs
+                            reportDTOs,
+                            null
                     );
                 })
                 .toList();
@@ -331,35 +337,114 @@ public class AdminService implements AdminPostUseCase, AdminUserUseCase {
     }
 
     @Override
+    @Transactional
     public void deletePost(AdminDeletePostCommand command) {
         // admin 존재 여부 확인
         Admin admin = adminPort.findByAdminId(command.getAdminId());
-
-        Long postId = command.getPostId();
-        postPort.deleteById(postId);
+        postPort.deleteById(command.getPostId());
     }
 
     @Override
+    @Transactional
     public void deleteUser(AdminDeleteUserCommand command) {
         // admin 존재 여부 확인
         Admin admin = adminPort.findByAdminId(command.getAdminId());
-
-        Long userId = command.getUserId();
-        userPort.deleteUser(userId);
+        userPort.deleteUser(command.getUserId());
     }
 
     @Override
+    @Transactional
     public void softDeletePost(AdminSoftDeletePostCommand command) {
-
+        Admin admin = adminPort.findByAdminId(command.getAdminId());
+        adminPostPort.softDelete(command.getPostId());
     }
 
     @Override
     public DeletedPostListResponseDTO getDeletedPosts(AdminGetDeletedPostsCommand command) {
-        return null;
+        // 1. 관리자 존재 여부 확인
+        Admin admin = adminPort.findByAdminId(command.getAdminId());
+
+        int page = command.getPage();
+        int size = command.getSize();
+
+        // 1. 삭제된 게시글 페이징 조회
+        List<Post> deletedPosts = adminPostPort.findDeleted(page, size);
+        int total = adminPostPort.countDeletedPosts();
+        int totalPages = (int) Math.ceil((double) total / size);
+
+        // 2. 게시글 ID 추출
+        List<Long> postIds = deletedPosts.stream()
+                .map(Post::getPostId)
+                .toList();
+
+        // 3. 신고 정보 조회
+        Map<Long, List<Report>> reportsByPostId = reportPort.findReportsByPostIds(postIds);
+
+        // 4. DTO 매핑
+        List<AdminPostResponseDTO> postDTOs = deletedPosts.stream()
+                .map(post -> {
+                    User author = post.getUser();
+                    Place place = post.getPlace();
+
+                    List<Photo> photos = postPort.findPhotoById(post.getPostId());
+                    List<Menu> menus = postPort.findMenuById(post.getPostId());
+
+                    List<String> imageUrls = photos.stream()
+                            .map(Photo::getPhotoUrl)
+                            .toList();
+
+                    List<AdminPostResponseDTO.MenuDTO> menuDTOs = menus.stream()
+                            .map(menu -> AdminPostResponseDTO.MenuDTO.of(
+                                    String.valueOf(menu.getMenuId()),
+                                    menu.getMenuName()
+                            ))
+                            .toList();
+
+                    List<Report> reports = reportsByPostId.getOrDefault(post.getPostId(), List.of());
+
+                    int reportCount = reports.size();
+                    boolean isReported = reportCount > 0;
+
+                    List<AdminPostResponseDTO.ReportDTO> reportDTOs = reports.stream()
+                            .map(report -> AdminPostResponseDTO.ReportDTO.of(
+                                    String.valueOf(report.getReportId()),
+                                    report.getReportType().name(),
+                                    report.getReportDetail(),
+                                    report.getUser().getUserName(),
+                                    report.getCreatedAt()
+                            ))
+                            .toList();
+
+                    return AdminPostResponseDTO.of(
+                            String.valueOf(post.getPostId()),
+                            String.valueOf(author.getUserId()),
+                            author.getUserName(),
+                            post.getDescription(),
+                            place.getPlaceName(),
+                            post.getCons(),
+                            imageUrls,
+                            place.getPlaceAddress(),
+                            menuDTOs,
+                            post.getCreatedAt(),
+                            post.getUpdatedAt(),
+                            isReported,
+                            reportCount,
+                            reportDTOs,
+                            post.getDeletedAt()
+                    );
+                })
+                .toList();
+
+        // 5. 페이징 정보
+        Pagination pagination = Pagination.of(page, size, total, totalPages);
+
+        return DeletedPostListResponseDTO.of(postDTOs, pagination);
     }
 
     @Override
+    @Transactional
     public void restorePost(AdminRestorePostCommand command) {
-
+        Admin admin = adminPort.findByAdminId(command.getAdminId());
+        adminPostPort.restore(command.getPostId());
     }
 }

--- a/src/main/java/com/spoony/spoony_server/domain/post/Post.java
+++ b/src/main/java/com/spoony/spoony_server/domain/post/Post.java
@@ -19,6 +19,8 @@ public class Post {
     private Long zzimCount;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    private boolean isDeleted;
+    private LocalDateTime deletedAt;
 
     public Post(User user, Place place, String description, Double value, String cons, Long zzimCount, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.user = user;


### PR DESCRIPTION
📝 Work Description
- 관리자 전용 삭제/복구 및 삭제된 게시글 조회 기능 추가
- `PostRepository` 에서 `is_deleted` 조건을 포함한 Native Query 작성
- `AdminPostPersistenceAdapter` 를 통해 삭제된 글 목록 및 개수 조회 가능하도록 구현

⚙️ Issue
- closed #201

🔨 Changes
- `AdminPostPort`, `AdminPostPersistenceAdapter` 추가 및 구현
- `PostRepository` 에 삭제된 게시글 조회 / 카운트용 Native Query 추가
- `AdminService` 에서 삭제, 복구, 삭제글 조회 기능 연결

🔍 PR Point
- `@SQLRestriction` 사용 시 관리자용 조회에 제한이 생겨 Native Query 방식으로 구현 
- Native Query 대신 @Filter or QueryDSL 도입이 더 적절할지 검토 필요
- 현재는 삭제글 조회만 관리자 전용이며, 일반 조회는 기존 로직 유지