### PR TITLE
[FEAT] 게시글 삭제, 복구 구현

### DIFF
--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/admin/mapper/AdminPostMapper.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/admin/mapper/AdminPostMapper.java
@@ -1,0 +1,72 @@
+package com.spoony.spoony_server.adapter.out.persistence.admin.mapper;
+
+import com.spoony.spoony_server.adapter.dto.admin.response.AdminPostResponseDTO;
+import com.spoony.spoony_server.application.port.out.post.PostPort;
+import com.spoony.spoony_server.domain.place.Place;
+import com.spoony.spoony_server.domain.post.Photo;
+import com.spoony.spoony_server.domain.post.Post;
+import com.spoony.spoony_server.domain.report.Report;
+import com.spoony.spoony_server.domain.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class AdminPostMapper {
+
+    private final PostPort postPort;
+
+    public AdminPostResponseDTO toDto(Post post, List<Report> reports) {
+        User author = post.getUser();
+        Place place = post.getPlace();
+
+        List<String> imageUrls = postPort.findPhotoById(post.getPostId()).stream()
+                .map(Photo::getPhotoUrl)
+                .toList();
+
+        List<AdminPostResponseDTO.MenuDTO> menuDTOs = postPort.findMenuById(post.getPostId()).stream()
+                .map(menu -> AdminPostResponseDTO.MenuDTO.of(
+                        String.valueOf(menu.getMenuId()), menu.getMenuName()))
+                .toList();
+
+        int reportCount = reports.size();
+        boolean isReported = reportCount > 0;
+
+        List<AdminPostResponseDTO.ReportDTO> reportDTOs = isReported
+                ? reports.stream().map(report -> AdminPostResponseDTO.ReportDTO.of(
+                String.valueOf(report.getReportId()),
+                report.getReportType().name(),
+                report.getReportDetail(),
+                report.getUser().getUserName(),
+                report.getCreatedAt()
+        )).toList()
+                : null;
+
+        return AdminPostResponseDTO.of(
+                String.valueOf(post.getPostId()),
+                String.valueOf(author.getUserId()),
+                author.getUserName(),
+                post.getDescription(),
+                place.getPlaceName(),
+                post.getCons(),
+                imageUrls,
+                place.getPlaceAddress(),
+                menuDTOs,
+                post.getCreatedAt(),
+                post.getUpdatedAt(),
+                isReported,
+                reportCount,
+                reportDTOs,
+                post.getDeletedAt()
+        );
+    }
+
+    public List<AdminPostResponseDTO> mapPostsToDtos(List<Post> posts, Map<Long, List<Report>> reportsByPostId) {
+        return posts.stream()
+                .map(post -> toDto(post, reportsByPostId.getOrDefault(post.getPostId(), List.of())))
+                .toList();
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<PostEntity, Long> , JpaSpecificationExecutor<PostEntity> {
@@ -36,10 +37,10 @@ public interface PostRepository extends JpaRepository<PostEntity, Long> , JpaSpe
     @Query("SELECT COUNT(p) FROM PostEntity p WHERE p.user.userId = :userId")
     int countByUserId(@Param("userId") Long userId);
 
-    @Query(
-            value = "SELECT * FROM post WHERE is_deleted = true ORDER BY created_at DESC",
-            nativeQuery = true
-    )
+    @Query(value = "SELECT * FROM post WHERE post_id = :postId", nativeQuery = true)
+    Optional<PostEntity> findByIdIncludingDeleted(@Param("postId") Long postId);
+
+    @Query(value = "SELECT * FROM post WHERE is_deleted = true ORDER BY created_at DESC", nativeQuery = true)
     List<PostEntity> findDeletedPosts(Pageable pageable);
 
     @Query(value = "SELECT COUNT(*) FROM post WHERE is_deleted = true", nativeQuery = true)

--- a/src/main/java/com/spoony/spoony_server/application/port/out/admin/AdminPostPort.java
+++ b/src/main/java/com/spoony/spoony_server/application/port/out/admin/AdminPostPort.java
@@ -6,7 +6,8 @@ import java.util.List;
 
 public interface AdminPostPort {
     void softDelete(Long postId);   // 논리 삭제
-    void restore(Long postId);      // 복구
+    void restore(Long postId); // 복구
+    void physicalDelete(Long postId); // 물리 삭제
     List<Post> findDeleted(int page, int size); // 삭제된 게시글 조회
     int countDeletedPosts();
 }

--- a/src/main/java/com/spoony/spoony_server/application/service/admin/AdminService.java
+++ b/src/main/java/com/spoony/spoony_server/application/service/admin/AdminService.java
@@ -2,6 +2,7 @@ package com.spoony.spoony_server.application.service.admin;
 
 import com.spoony.spoony_server.adapter.dto.Pagination;
 import com.spoony.spoony_server.adapter.dto.admin.response.*;
+import com.spoony.spoony_server.adapter.out.persistence.admin.mapper.AdminPostMapper;
 import com.spoony.spoony_server.application.auth.port.out.AdminPort;
 import com.spoony.spoony_server.application.port.command.admin.*;
 import com.spoony.spoony_server.application.port.in.admin.*;
@@ -10,9 +11,6 @@ import com.spoony.spoony_server.application.port.out.post.PostPort;
 import com.spoony.spoony_server.application.port.out.report.ReportPort;
 import com.spoony.spoony_server.application.port.out.user.UserPort;
 import com.spoony.spoony_server.domain.admin.Admin;
-import com.spoony.spoony_server.domain.place.Place;
-import com.spoony.spoony_server.domain.post.Menu;
-import com.spoony.spoony_server.domain.post.Photo;
 import com.spoony.spoony_server.domain.post.Post;
 import com.spoony.spoony_server.domain.report.Report;
 import com.spoony.spoony_server.domain.report.UserReport;
@@ -36,190 +34,59 @@ public class AdminService implements AdminPostUseCase, AdminUserUseCase {
     private final UserPort userPort;
     private final AdminPort adminPort;
     private final AdminPostPort adminPostPort;
+    private final AdminPostMapper adminPostMapper;
 
     @Override
     public AdminPostListResponseDTO getAllPosts(AdminGetAllPostsCommand command) {
-        // admin 존재 여부 확인
-        Admin admin = adminPort.findByAdminId(command.getAdminId());
+        adminPort.findByAdminId(command.getAdminId());
 
-        int page = command.getPage();
-        int size = command.getSize();
-
-        // 1. 전체 게시글 페이징 조회
-        List<Post> posts = postPort.findAllPosts(page, size);
+        List<Post> posts = postPort.findAllPosts(command.getPage(), command.getSize());
         int total = postPort.countAllPosts();
-        int totalPages = (int) Math.ceil((double) total / size);
+        int totalPages = (int) Math.ceil((double) total / command.getSize());
 
-        // 2. 게시글 ID 추출
-        List<Long> postIds = posts.stream()
-                .map(Post::getPostId)
-                .toList();
+        Map<Long, List<Report>> reportsByPostId =
+                reportPort.findReportsByPostIds(posts.stream().map(Post::getPostId).toList());
 
-        // 3. 게시글별 신고 정보 조회
-        Map<Long, List<Report>> reportsByPostId = reportPort.findReportsByPostIds(postIds);
+        List<AdminPostResponseDTO> postDTOs = adminPostMapper.mapPostsToDtos(posts, reportsByPostId);
 
-        // 4. 게시글 DTO로 변환
-        List<AdminPostResponseDTO> postDTOs = posts.stream()
-                .map(post -> {
-                    User author = post.getUser();
-                    Place place = post.getPlace();
-
-                    List<Photo> photos = postPort.findPhotoById(post.getPostId());
-                    List<Menu> menus = postPort.findMenuById(post.getPostId());
-
-                    List<String> imageUrls = photos.stream()
-                            .map(Photo::getPhotoUrl)
-                            .toList();
-
-                    List<AdminPostResponseDTO.MenuDTO> menuDTOs = menus.stream()
-                            .map(menu -> AdminPostResponseDTO.MenuDTO.of(
-                                    String.valueOf(menu.getMenuId()),
-                                    menu.getMenuName()
-                            ))
-                            .toList();
-
-                    List<Report> reports = reportsByPostId.getOrDefault(post.getPostId(), List.of());
-
-                    boolean isReported = !reports.isEmpty();
-                    int reportCount = reports.size();
-
-                    List<AdminPostResponseDTO.ReportDTO> reportDTOs = isReported
-                            ? reports.stream().map(report -> AdminPostResponseDTO.ReportDTO.of(
-                            String.valueOf(report.getReportId()),
-                            report.getReportType().name(),
-                            report.getReportDetail(),
-                            report.getUser().getUserName(), // 신고자
-                            report.getCreatedAt()
-                    )).toList()
-                            : null;
-
-                    return AdminPostResponseDTO.of(
-                            String.valueOf(post.getPostId()),
-                            String.valueOf(author.getUserId()),
-                            author.getUserName(),
-                            post.getDescription(),
-                            place.getPlaceName(),
-                            post.getCons(),
-                            imageUrls,
-                            place.getPlaceAddress(),
-                            menuDTOs,
-                            post.getCreatedAt(),
-                            post.getUpdatedAt(),
-                            isReported,
-                            reportCount,
-                            reportDTOs,
-                            null
-                    );
-                })
-                .toList();
-
-        Pagination pagination = Pagination.of(page, size, total, totalPages);
-        return AdminPostListResponseDTO.of(postDTOs, pagination);
+        return AdminPostListResponseDTO.of(postDTOs,
+                Pagination.of(command.getPage(), command.getSize(), total, totalPages));
     }
 
     @Override
     public ReportedPostListResponseDTO getReportedPosts(AdminGetReportedPostsCommand command) {
-        // admin 존재 여부 확인
-        Admin admin = adminPort.findByAdminId(command.getAdminId());
+        adminPort.findByAdminId(command.getAdminId());
 
-        int page = command.getPage();
-        int size = command.getSize();
-
-        // 1. 신고된 게시글 페이징 조회
-        List<Post> reportedPosts = postPort.findReportedPosts(page, size);
+        List<Post> reportedPosts = postPort.findReportedPosts(command.getPage(), command.getSize());
         int total = postPort.countReportedPosts();
-        int totalPages = (int) Math.ceil((double) total / size);
+        int totalPages = (int) Math.ceil((double) total / command.getSize());
 
-        // 2. 게시글 ID 추출
-        List<Long> postIds = reportedPosts.stream()
-                .map(Post::getPostId)
-                .toList();
+        Map<Long, List<Report>> reportsByPostId =
+                reportPort.findReportsByPostIds(reportedPosts.stream().map(Post::getPostId).toList());
 
-        // 3. 게시글별 신고 정보 조회
-        Map<Long, List<Report>> reportsByPostId = reportPort.findReportsByPostIds(postIds);
+        List<AdminPostResponseDTO> postDTOs = adminPostMapper.mapPostsToDtos(reportedPosts, reportsByPostId);
 
-        // 4. 게시글 DTO 변환
-        List<AdminPostResponseDTO> postDTOs = reportedPosts.stream()
-                .map(post -> {
-                    User author = post.getUser();
-                    Place place = post.getPlace();
-
-                    List<Photo> photos = postPort.findPhotoById(post.getPostId());
-                    List<Menu> menus = postPort.findMenuById(post.getPostId());
-
-                    List<String> imageUrls = photos.stream()
-                            .map(Photo::getPhotoUrl)
-                            .toList();
-
-                    List<AdminPostResponseDTO.MenuDTO> menuDTOs = menus.stream()
-                            .map(menu -> AdminPostResponseDTO.MenuDTO.of(
-                                    String.valueOf(menu.getMenuId()),
-                                    menu.getMenuName()
-                            ))
-                            .toList();
-
-                    List<Report> reports = reportsByPostId.getOrDefault(post.getPostId(), List.of());
-
-                    int reportCount = reports.size();
-
-                    List<AdminPostResponseDTO.ReportDTO> reportDTOs = reports.stream()
-                            .map(report -> AdminPostResponseDTO.ReportDTO.of(
-                                    String.valueOf(report.getReportId()),
-                                    report.getReportType().name(),
-                                    report.getReportDetail(),
-                                    report.getUser().getUserName(),
-                                    report.getCreatedAt()
-                            ))
-                            .toList();
-
-                    return AdminPostResponseDTO.of(
-                            String.valueOf(post.getPostId()),
-                            String.valueOf(author.getUserId()),
-                            author.getUserName(),
-                            post.getDescription(),
-                            place.getPlaceName(),
-                            post.getCons(),
-                            imageUrls,
-                            place.getPlaceAddress(),
-                            menuDTOs,
-                            post.getCreatedAt(),
-                            post.getUpdatedAt(),
-                            true,
-                            reportCount,
-                            reportDTOs,
-                            null
-                    );
-                })
-                .toList();
-
-        Pagination pagination = Pagination.of(page, size, total, totalPages);
-        return ReportedPostListResponseDTO.of(postDTOs, pagination);
+        return ReportedPostListResponseDTO.of(postDTOs,
+                Pagination.of(command.getPage(), command.getSize(), total, totalPages));
     }
 
     @Override
     public ReportedUserListResponseDTO getReportedUsers(AdminGetReportedUsersCommand command) {
-        // admin 존재 여부 확인
-        Admin admin = adminPort.findByAdminId(command.getAdminId());
+        adminPort.findByAdminId(command.getAdminId());
 
-        int page = command.getPage();
-        int size = command.getSize();
-
-        // 1. 페이징 처리된 신고 대상 유저 목록 및 신고 내역 조회
-        List<UserReport> userReports = reportPort.findUserReportsWithPagination(page, size);
+        List<UserReport> userReports = reportPort.findUserReportsWithPagination(command.getPage(), command.getSize());
         int total = reportPort.countReportedUsers();
-        int totalPages = (int) Math.ceil((double) total / size);
+        int totalPages = (int) Math.ceil((double) total / command.getSize());
 
-        // 2. 사용자별 그룹핑
-        Map<Long, List<UserReport>> reportsByTargetUserId = userReports.stream()
-                .collect(Collectors.groupingBy(r -> r.getTargetUser().getUserId()));
+        Map<Long, List<UserReport>> reportsByTargetUserId =
+                userReports.stream().collect(Collectors.groupingBy(r -> r.getTargetUser().getUserId()));
 
-        // 3. DTO 변환
         List<ReportedUserResponseDTO> users = reportsByTargetUserId.entrySet().stream()
                 .map(entry -> {
                     Long userId = entry.getKey();
                     List<UserReport> reports = entry.getValue();
 
-                    User targetUser = reports.get(0).getTargetUser(); // 동일 대상
+                    User targetUser = reports.get(0).getTargetUser();
                     int reportCount = reports.size();
 
                     List<ReportedUserResponseDTO.ReportDTO> reportDTOs = reports.stream()
@@ -229,8 +96,7 @@ public class AdminService implements AdminPostUseCase, AdminUserUseCase {
                                     report.getUserReportDetail(),
                                     report.getReporter().getUserName(),
                                     report.getCreatedAt()
-                            ))
-                            .toList();
+                            )).toList();
 
                     return ReportedUserResponseDTO.of(
                             String.valueOf(userId),
@@ -241,99 +107,30 @@ public class AdminService implements AdminPostUseCase, AdminUserUseCase {
                 })
                 .toList();
 
-        Pagination pagination = Pagination.of(page, size, total, totalPages);
-        return ReportedUserListResponseDTO.of(users, pagination);
+        return ReportedUserListResponseDTO.of(users,
+                Pagination.of(command.getPage(), command.getSize(), total, totalPages));
     }
 
     @Override
     public UserPostListResponseDTO getPostsByUser(AdminGetUserPostsCommand command) {
-        // admin 존재 여부 확인
-        Admin admin = adminPort.findByAdminId(command.getAdminId());
+        adminPort.findByAdminId(command.getAdminId());
 
-        Long userId = command.getUserId();
-        int page = command.getPage();
-        int size = command.getSize();
+        List<Post> posts = postPort.findPostsByUserId(command.getUserId(), command.getPage(), command.getSize());
+        int total = postPort.countPostsByUserId(command.getUserId());
+        int totalPages = (int) Math.ceil((double) total / command.getSize());
 
-        // 1. 게시글 조회
-        List<Post> posts = postPort.findPostsByUserId(userId, page, size);
-        int total = postPort.countPostsByUserId(userId);
-        int totalPages = (int) Math.ceil((double) total / size);
+        Map<Long, List<Report>> reportsByPostId =
+                reportPort.findReportsByPostIds(posts.stream().map(Post::getPostId).toList());
 
-        // 2. 게시글 ID 추출
-        List<Long> postIds = posts.stream()
-                .map(Post::getPostId)
-                .toList();
+        List<AdminPostResponseDTO> postDTOs = adminPostMapper.mapPostsToDtos(posts, reportsByPostId);
 
-        // 3. 게시글별 신고 정보 조회
-        Map<Long, List<Report>> reportsByPostId = reportPort.findReportsByPostIds(postIds);
-
-        // 4. 게시글 DTO 매핑
-        List<AdminPostResponseDTO> postDTOs = posts.stream()
-                .map(post -> {
-                    User author = post.getUser();
-                    Place place = post.getPlace();
-
-                    // 게시글별 이미지, 메뉴 조회
-                    List<Photo> photos = postPort.findPhotoById(post.getPostId());
-                    List<Menu> menus = postPort.findMenuById(post.getPostId());
-
-                    List<String> imageUrls = photos.stream()
-                            .map(Photo::getPhotoUrl)
-                            .toList();
-
-                    List<AdminPostResponseDTO.MenuDTO> menuDTOs = menus.stream()
-                            .map(menu -> AdminPostResponseDTO.MenuDTO.of(
-                                    String.valueOf(menu.getMenuId()),
-                                    menu.getMenuName()))
-                            .toList();
-
-                    // 신고 정보
-                    List<Report> reports = reportsByPostId.getOrDefault(post.getPostId(), List.of());
-                    boolean isReported = !reports.isEmpty();
-                    int reportCount = reports.size();
-
-                    List<AdminPostResponseDTO.ReportDTO> reportDTOs = reports.stream()
-                            .map(report -> AdminPostResponseDTO.ReportDTO.of(
-                                    String.valueOf(report.getReportId()),
-                                    report.getReportType().name(),
-                                    report.getReportDetail(),
-                                    report.getUser().getUserName(),
-                                    report.getPost().getCreatedAt()
-                            ))
-                            .toList();
-
-                    return AdminPostResponseDTO.of(
-                            String.valueOf(post.getPostId()),
-                            String.valueOf(author.getUserId()),
-                            author.getUserName(),
-                            post.getDescription(),
-                            place.getPlaceName(),
-                            post.getCons(),
-                            imageUrls,
-                            place.getPlaceAddress(),
-                            menuDTOs,
-                            post.getCreatedAt(),
-                            post.getUpdatedAt(),
-                            isReported,
-                            reportCount,
-                            reportDTOs,
-                            null
-                    );
-                })
-                .toList();
-
-        // 5. 유저 정보 추출 (동일 유저 기준)
         User user = posts.isEmpty() ? null : posts.get(0).getUser();
-
         UserPostListResponseDTO.UserInfo userInfo = user != null
-                ? UserPostListResponseDTO.UserInfo.of(
-                String.valueOf(user.getUserId()),
-                user.getUserName())
+                ? UserPostListResponseDTO.UserInfo.of(String.valueOf(user.getUserId()), user.getUserName())
                 : null;
 
-        // 6. 응답 조립
-        Pagination pagination = Pagination.of(page, size, total, totalPages);
-        return UserPostListResponseDTO.of(userInfo, postDTOs, pagination);
+        return UserPostListResponseDTO.of(userInfo, postDTOs,
+                Pagination.of(command.getPage(), command.getSize(), total, totalPages));
     }
 
     @Override
@@ -341,7 +138,7 @@ public class AdminService implements AdminPostUseCase, AdminUserUseCase {
     public void deletePost(AdminDeletePostCommand command) {
         // admin 존재 여부 확인
         Admin admin = adminPort.findByAdminId(command.getAdminId());
-        postPort.deleteById(command.getPostId());
+        adminPostPort.physicalDelete(command.getPostId());
     }
 
     @Override
@@ -361,84 +158,19 @@ public class AdminService implements AdminPostUseCase, AdminUserUseCase {
 
     @Override
     public DeletedPostListResponseDTO getDeletedPosts(AdminGetDeletedPostsCommand command) {
-        // 1. 관리자 존재 여부 확인
-        Admin admin = adminPort.findByAdminId(command.getAdminId());
+        adminPort.findByAdminId(command.getAdminId());
 
-        int page = command.getPage();
-        int size = command.getSize();
-
-        // 1. 삭제된 게시글 페이징 조회
-        List<Post> deletedPosts = adminPostPort.findDeleted(page, size);
+        List<Post> deletedPosts = adminPostPort.findDeleted(command.getPage(), command.getSize());
         int total = adminPostPort.countDeletedPosts();
-        int totalPages = (int) Math.ceil((double) total / size);
+        int totalPages = (int) Math.ceil((double) total / command.getSize());
 
-        // 2. 게시글 ID 추출
-        List<Long> postIds = deletedPosts.stream()
-                .map(Post::getPostId)
-                .toList();
+        Map<Long, List<Report>> reportsByPostId =
+                reportPort.findReportsByPostIds(deletedPosts.stream().map(Post::getPostId).toList());
 
-        // 3. 신고 정보 조회
-        Map<Long, List<Report>> reportsByPostId = reportPort.findReportsByPostIds(postIds);
+        List<AdminPostResponseDTO> postDTOs = adminPostMapper.mapPostsToDtos(deletedPosts, reportsByPostId);
 
-        // 4. DTO 매핑
-        List<AdminPostResponseDTO> postDTOs = deletedPosts.stream()
-                .map(post -> {
-                    User author = post.getUser();
-                    Place place = post.getPlace();
-
-                    List<Photo> photos = postPort.findPhotoById(post.getPostId());
-                    List<Menu> menus = postPort.findMenuById(post.getPostId());
-
-                    List<String> imageUrls = photos.stream()
-                            .map(Photo::getPhotoUrl)
-                            .toList();
-
-                    List<AdminPostResponseDTO.MenuDTO> menuDTOs = menus.stream()
-                            .map(menu -> AdminPostResponseDTO.MenuDTO.of(
-                                    String.valueOf(menu.getMenuId()),
-                                    menu.getMenuName()
-                            ))
-                            .toList();
-
-                    List<Report> reports = reportsByPostId.getOrDefault(post.getPostId(), List.of());
-
-                    int reportCount = reports.size();
-                    boolean isReported = reportCount > 0;
-
-                    List<AdminPostResponseDTO.ReportDTO> reportDTOs = reports.stream()
-                            .map(report -> AdminPostResponseDTO.ReportDTO.of(
-                                    String.valueOf(report.getReportId()),
-                                    report.getReportType().name(),
-                                    report.getReportDetail(),
-                                    report.getUser().getUserName(),
-                                    report.getCreatedAt()
-                            ))
-                            .toList();
-
-                    return AdminPostResponseDTO.of(
-                            String.valueOf(post.getPostId()),
-                            String.valueOf(author.getUserId()),
-                            author.getUserName(),
-                            post.getDescription(),
-                            place.getPlaceName(),
-                            post.getCons(),
-                            imageUrls,
-                            place.getPlaceAddress(),
-                            menuDTOs,
-                            post.getCreatedAt(),
-                            post.getUpdatedAt(),
-                            isReported,
-                            reportCount,
-                            reportDTOs,
-                            post.getDeletedAt()
-                    );
-                })
-                .toList();
-
-        // 5. 페이징 정보
-        Pagination pagination = Pagination.of(page, size, total, totalPages);
-
-        return DeletedPostListResponseDTO.of(postDTOs, pagination);
+        return DeletedPostListResponseDTO.of(postDTOs,
+                Pagination.of(command.getPage(), command.getSize(), total, totalPages));
     }
 
     @Override


### PR DESCRIPTION
### 📝 Work Description
- Admin 게시글 삭제/복구/조회 기능을 헥사고날 아키텍처에 맞게 리팩토링  
- `@SQLRestriction` 제약으로 soft deleted 데이터가 기본 JPA 조회에서 제외됨을 고려해 Native Query 기반의 조회 및 물리 삭제 기능 구현.

### ⚙️ Issue
- closed #201 

### 🔨 Changes
- `Persistence Adapter`
  - `softDelete / restore`: 엔티티 메서드 호출 후 save  
  - `physicalDelete`: Native DELETE 사용 (필터 우회)  
  - `findDeleted / countDeletedPosts`: Native Query로 삭제된 게시글만 조회

- `Service` 계층  
  - 어드민 인증 후 포트 호출  
  - DTO 변환은 `AdminPostMapper`로 위임 (중복 로직 제거)

### 🔍 PR Point
- `@SQLRestriction` 때문에 일반 JPA 조회에서는 soft deleted 데이터 접근이 불가능 → Admin 전용 기능은 Native Query로 처리  
- Mapper 도입으로 DTO 변환 로직을 서비스에서 분리, 가독성과 유지보수성 개선

### 📌 Logical Justification
- 아키텍처 일관성 유지
   - 헥사고날 아키텍처 원칙에 따라 비즈니스 로직(Service)와 데이터 접근(Persistence)을 철저히 분리.  
   - 포트-어댑터 패턴으로 서비스는 `postPort` / `adminPostPort`만 의존

- 유지보수성 & 확장성
   - DTO 변환을 Mapper로 추출하여 서비스 코드 단순화