### PR TITLE
[FEAT] 애플 탈퇴 구현

### DIFF
--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -38,6 +38,11 @@ jobs:
           echo "${{ secrets.CD_APPLICATION_NAVER }}" > ./src/main/resources/application-naver.yml
           echo "${{ secrets.CD_APPLICATION_OATH }}" > ./src/main/resources/application-oath.yml
 
+      - name: Generate Apple p8 key
+        run: |
+          mkdir -p ./src/main/resources/key
+          echo "${{ secrets.APPLE_P8 }}" > ./src/main/resources/key/AuthKey_JDTJBM88K5.p8
+
       - name: Build Project
         run: ./gradlew clean build -x test
 

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/dto/request/PlatformRequestDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/dto/request/PlatformRequestDTO.java
@@ -3,4 +3,5 @@ package com.spoony.spoony_server.adapter.auth.dto.request;
 import com.spoony.spoony_server.domain.user.Platform;
 import jakarta.validation.constraints.NotNull;
 
-public record PlatformRequestDTO(@NotNull(message = "플랫폼은 필수 값입니다.") Platform platform) {}
+public record PlatformRequestDTO(@NotNull(message = "플랫폼은 필수 값입니다.") Platform platform,
+                                 String authCode) {}

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/dto/request/UserSignupDTO.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/dto/request/UserSignupDTO.java
@@ -9,5 +9,6 @@ public record UserSignupDTO(@NotNull(message = "플랫폼은 필수 값입니다
                             @NotNull(message = "사용자 이름은 필수 값입니다.") String userName,
                             LocalDate birth,
                             Long regionId,
-                            String introduction) {
+                            String introduction,
+                            String authCode) {
 }

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/in/web/AuthController.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/in/web/AuthController.java
@@ -9,7 +9,6 @@ import com.spoony.spoony_server.application.auth.port.in.*;
 import com.spoony.spoony_server.global.auth.annotation.UserId;
 import com.spoony.spoony_server.global.auth.constant.AuthConstant;
 import com.spoony.spoony_server.global.dto.ResponseDTO;
-import io.micrometer.common.lang.Nullable;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -44,7 +43,7 @@ public class AuthController {
     @Operation(summary = "로그인 API", description = "사용자 로그인 API, 성공 시 Token Set, 실패 시 회원가입이 필요합니다.")
     public ResponseEntity<ResponseDTO<LoginResponseDTO>> login(
             @NotBlank @RequestHeader(AuthConstant.AUTHORIZATION_HEADER) final String platformToken,
-            @RequestBody final PlatformRequestDTO platformRequestDTO
+            @Valid @RequestBody final PlatformRequestDTO platformRequestDTO
     ) {
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(loginUseCase.login(platformRequestDTO, platformToken)));
     }
@@ -61,8 +60,7 @@ public class AuthController {
     @PostMapping("/withdraw")
     @Operation(summary = "회원 탈퇴 API", description = "마이페이지 > 설정에서 회원 탈퇴합니다.")
     public ResponseEntity<ResponseDTO<Void>> withdraw(
-            @UserId Long userId,
-            @Nullable @RequestHeader(value = AuthConstant.APPLE_WITHDRAW_HEADER, required = false) final String authCode
+            @UserId Long userId
     ) {
         withdrawUseCase.withdraw(userId);
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(null));
@@ -73,7 +71,6 @@ public class AuthController {
     public ResponseEntity<ResponseDTO<JwtTokenDTO>> refreshAccessToken(
             @NotBlank @RequestHeader(AuthConstant.AUTHORIZATION_HEADER) String refreshToken
     ) {
-        System.out.println("초기 요청 토큰 " + refreshToken);
         if (refreshToken.startsWith(BEARER_TOKEN_PREFIX)) {
             refreshToken = refreshToken.substring(BEARER_TOKEN_PREFIX.length());
         }

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/in/web/AuthController.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/in/web/AuthController.java
@@ -6,7 +6,6 @@ import com.spoony.spoony_server.adapter.auth.dto.response.JwtTokenDTO;
 import com.spoony.spoony_server.adapter.auth.dto.response.LoginResponseDTO;
 import com.spoony.spoony_server.adapter.auth.dto.response.UserTokenDTO;
 import com.spoony.spoony_server.application.auth.port.in.*;
-import com.spoony.spoony_server.domain.user.Platform;
 import com.spoony.spoony_server.global.auth.annotation.UserId;
 import com.spoony.spoony_server.global.auth.constant.AuthConstant;
 import com.spoony.spoony_server.global.dto.ResponseDTO;
@@ -47,7 +46,7 @@ public class AuthController {
             @NotBlank @RequestHeader(AuthConstant.AUTHORIZATION_HEADER) final String platformToken,
             @RequestBody final PlatformRequestDTO platformRequestDTO
     ) {
-        return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(loginUseCase.login(platformRequestDTO.platform(), platformToken)));
+        return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(loginUseCase.login(platformRequestDTO, platformToken)));
     }
 
     @PostMapping("/logout")
@@ -65,7 +64,7 @@ public class AuthController {
             @UserId Long userId,
             @Nullable @RequestHeader(value = AuthConstant.APPLE_WITHDRAW_HEADER, required = false) final String authCode
     ) {
-        withdrawUseCase.withdraw(userId, authCode);
+        withdrawUseCase.withdraw(userId);
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.success(null));
     }
 

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/out/persistence/AppleRefreshTokenAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/out/persistence/AppleRefreshTokenAdapter.java
@@ -20,13 +20,20 @@ public class AppleRefreshTokenAdapter implements AppleRefreshTokenPort {
     @Override
     @Transactional
     public void upsert(Long userId, String refreshToken) {
-        AppleRefreshTokenEntity entity = appleRefreshTokenRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(UserErrorMessage.USER_NOT_FOUND));
-        entity.setRefreshToken(refreshToken);
-        appleRefreshTokenRepository.save(entity);
+        appleRefreshTokenRepository.findById(userId)
+            .ifPresentOrElse(entity -> {
+                entity.setRefreshToken(refreshToken);
+            }, () -> {
+            AppleRefreshTokenEntity newEntity = AppleRefreshTokenEntity.builder()
+                .userId(userId)
+                .refreshToken(refreshToken)
+                .build();
+            appleRefreshTokenRepository.save(newEntity);
+        });
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Optional<String> findRefreshTokenByUserId(Long userId) {
         return appleRefreshTokenRepository.findById(userId).map(AppleRefreshTokenEntity::getRefreshToken);
     }

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/out/persistence/AppleRefreshTokenAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/out/persistence/AppleRefreshTokenAdapter.java
@@ -1,0 +1,41 @@
+package com.spoony.spoony_server.adapter.auth.out.persistence;
+
+import com.spoony.spoony_server.adapter.out.persistence.user.db.AppleRefreshTokenEntity;
+import com.spoony.spoony_server.adapter.out.persistence.user.db.AppleRefreshTokenRepository;
+import com.spoony.spoony_server.application.auth.port.out.AppleRefreshTokenPort;
+import com.spoony.spoony_server.global.annotation.Adapter;
+import com.spoony.spoony_server.global.exception.BusinessException;
+import com.spoony.spoony_server.global.message.business.UserErrorMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Adapter
+@RequiredArgsConstructor
+public class AppleRefreshTokenAdapter implements AppleRefreshTokenPort {
+
+    private final AppleRefreshTokenRepository appleRefreshTokenRepository;
+
+    @Override
+    @Transactional
+    public void upsert(Long userId, String refreshToken) {
+        AppleRefreshTokenEntity entity = appleRefreshTokenRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorMessage.USER_NOT_FOUND));
+        entity.setRefreshToken(refreshToken);
+        appleRefreshTokenRepository.save(entity);
+    }
+
+    @Override
+    public Optional<String> findRefreshTokenByUserId(Long userId) {
+        return appleRefreshTokenRepository.findById(userId).map(AppleRefreshTokenEntity::getRefreshToken);
+    }
+
+    @Override
+    @Transactional
+    public void revoke(Long userId) {
+        AppleRefreshTokenEntity entity = appleRefreshTokenRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorMessage.USER_NOT_FOUND));
+        appleRefreshTokenRepository.delete(entity);
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/auth/verification/apple/AppleClientSecretGenerator.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/auth/verification/apple/AppleClientSecretGenerator.java
@@ -54,7 +54,7 @@ public class AppleClientSecretGenerator {
                 .setExpiration(expirationDate) // 만료 시간
                 .setAudience(AUDIENCE) // aud
                 .setSubject(clientId) // sub
-                .signWith(SignatureAlgorithm.ES256, getPrivateKey())
+                .signWith(getPrivateKey(), SignatureAlgorithm.ES256)
                 .compact();
     }
 

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/user/db/AppleRefreshTokenEntity.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/user/db/AppleRefreshTokenEntity.java
@@ -1,9 +1,7 @@
 package com.spoony.spoony_server.adapter.out.persistence.user.db;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -15,13 +13,15 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Getter
 @Setter
+@Builder
+@AllArgsConstructor
 public class AppleRefreshTokenEntity {
 
     @Id
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    @Column(name = "refresh_token", nullable = false)
+    @Column(name = "refresh_token", nullable = false, length = 2048)
     private String refreshToken;
 
     @CreatedDate

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/user/db/AppleRefreshTokenEntity.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/user/db/AppleRefreshTokenEntity.java
@@ -1,5 +1,6 @@
 package com.spoony.spoony_server.adapter.out.persistence.user.db;
 
+import com.spoony.spoony_server.global.auth.encryptor.AppleRefreshTokenEncryptor;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -21,6 +22,7 @@ public class AppleRefreshTokenEntity {
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
+    @Convert(converter = AppleRefreshTokenEncryptor.class)
     @Column(name = "refresh_token", nullable = false, length = 2048)
     private String refreshToken;
 

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/user/db/AppleRefreshTokenEntity.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/user/db/AppleRefreshTokenEntity.java
@@ -1,0 +1,29 @@
+package com.spoony.spoony_server.adapter.out.persistence.user.db;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "apple_refresh_token")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor
+@Getter
+@Setter
+public class AppleRefreshTokenEntity {
+
+    @Id
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "refresh_token", nullable = false)
+    private String refreshToken;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/user/db/AppleRefreshTokenRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/user/db/AppleRefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package com.spoony.spoony_server.adapter.out.persistence.user.db;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AppleRefreshTokenRepository extends JpaRepository<AppleRefreshTokenEntity, Long> {
+}

--- a/src/main/java/com/spoony/spoony_server/application/auth/port/in/LoginUseCase.java
+++ b/src/main/java/com/spoony/spoony_server/application/auth/port/in/LoginUseCase.java
@@ -1,8 +1,9 @@
 package com.spoony.spoony_server.application.auth.port.in;
 
+import com.spoony.spoony_server.adapter.auth.dto.request.PlatformRequestDTO;
 import com.spoony.spoony_server.adapter.auth.dto.response.LoginResponseDTO;
 import com.spoony.spoony_server.domain.user.Platform;
 
 public interface LoginUseCase {
-    LoginResponseDTO login(Platform platform, String platformToken);
+    LoginResponseDTO login(PlatformRequestDTO platformRequestDTO, String platformToken);
 }

--- a/src/main/java/com/spoony/spoony_server/application/auth/port/in/WithdrawUseCase.java
+++ b/src/main/java/com/spoony/spoony_server/application/auth/port/in/WithdrawUseCase.java
@@ -1,5 +1,5 @@
 package com.spoony.spoony_server.application.auth.port.in;
 
 public interface WithdrawUseCase {
-    void withdraw(Long userId, String authCode);
+    void withdraw(Long userId);
 }

--- a/src/main/java/com/spoony/spoony_server/application/auth/port/out/AppleRefreshTokenPort.java
+++ b/src/main/java/com/spoony/spoony_server/application/auth/port/out/AppleRefreshTokenPort.java
@@ -1,0 +1,9 @@
+package com.spoony.spoony_server.application.auth.port.out;
+
+import java.util.Optional;
+
+public interface AppleRefreshTokenPort {
+    void upsert(Long userId, String refreshToken);
+    Optional<String> findRefreshTokenByUserId(Long userId);
+    void revoke(Long userId);
+}

--- a/src/main/java/com/spoony/spoony_server/application/auth/service/AppleService.java
+++ b/src/main/java/com/spoony/spoony_server/application/auth/service/AppleService.java
@@ -10,8 +10,10 @@ import com.spoony.spoony_server.adapter.auth.verification.apple.ApplePublicKeyGe
 import com.spoony.spoony_server.application.auth.port.out.AppleRefreshTokenPort;
 import com.spoony.spoony_server.global.exception.AuthException;
 import com.spoony.spoony_server.global.message.auth.AuthErrorMessage;
+import feign.FeignException;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.security.PublicKey;
 import java.util.Map;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AppleService {
@@ -60,7 +63,11 @@ public class AppleService {
                 throw new AuthException(AuthErrorMessage.EMPTY_REFRESH_TOKEN);
             }
             appleRefreshTokenPort.upsert(userId, tokenDTO.refreshToken());
+        } catch (FeignException e) {
+            log.error("[Apple Token] status={}, body={}", e.status(), e.contentUTF8());
+            throw new AuthException(AuthErrorMessage.APPLE_TOKEN_REQUEST_FAILED);
         } catch (Exception e) {
+            log.error("[Apple Token] unexpected error", e);
             throw new AuthException(AuthErrorMessage.APPLE_TOKEN_REQUEST_FAILED);
         }
     }

--- a/src/main/java/com/spoony/spoony_server/application/auth/service/AuthService.java
+++ b/src/main/java/com/spoony/spoony_server/application/auth/service/AuthService.java
@@ -1,11 +1,13 @@
 package com.spoony.spoony_server.application.auth.service;
 
 import com.spoony.spoony_server.adapter.auth.dto.PlatformUserDTO;
+import com.spoony.spoony_server.adapter.auth.dto.request.PlatformRequestDTO;
 import com.spoony.spoony_server.adapter.auth.dto.request.UserSignupDTO;
 import com.spoony.spoony_server.adapter.auth.dto.response.JwtTokenDTO;
 import com.spoony.spoony_server.adapter.auth.dto.response.LoginResponseDTO;
 import com.spoony.spoony_server.adapter.auth.dto.response.UserTokenDTO;
 import com.spoony.spoony_server.application.auth.port.in.*;
+import com.spoony.spoony_server.application.auth.port.out.AppleRefreshTokenPort;
 import com.spoony.spoony_server.application.auth.port.out.TokenPort;
 import com.spoony.spoony_server.application.port.out.user.UserPort;
 import com.spoony.spoony_server.domain.user.Platform;
@@ -30,6 +32,7 @@ public class AuthService implements
 
     private final UserPort userPort;
     private final TokenPort tokenPort;
+    private final AppleRefreshTokenPort appleRefreshTokenPort;
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtTokenValidator jwtTokenValidator;
     private final AppleService appleService;
@@ -39,18 +42,28 @@ public class AuthService implements
     public UserTokenDTO signup(String platformToken, UserSignupDTO userSignupDTO) {
         PlatformUserDTO platformUserDTO = getPlatformInfo(platformToken, userSignupDTO);
         User user = userPort.create(platformUserDTO, userSignupDTO);
+
+        if (userSignupDTO.platform() == Platform.APPLE) {
+            appleService.exchangeAndStoreRefreshToken(userSignupDTO.authCode(), user.getUserId());
+        }
+
         JwtTokenDTO token = jwtTokenProvider.generateTokenPair(user.getUserId());
         tokenPort.saveToken(user.getUserId(), token);
         return UserTokenDTO.of(user, token);
     }
 
     @Override
-    public LoginResponseDTO login(Platform platform, String platformToken) {
-        PlatformUserDTO platformUserDTO = getPlatformInfo(platform, platformToken);
-        User user = userPort.load(platform, platformUserDTO);
+    public LoginResponseDTO login(PlatformRequestDTO platformRequestDTO, String platformToken) {
+        PlatformUserDTO platformUserDTO = getPlatformInfo(platformRequestDTO.platform(), platformToken);
+        User user = userPort.load(platformRequestDTO.platform(), platformUserDTO);
 
         if (user == null) {
             return LoginResponseDTO.of(false, null, null);
+        }
+
+        if (platformRequestDTO.platform() == Platform.APPLE
+                && appleRefreshTokenPort.findRefreshTokenByUserId(user.getUserId()).isEmpty()) {
+            appleService.exchangeAndStoreRefreshToken(platformRequestDTO.authCode(), user.getUserId());
         }
 
         JwtTokenDTO token = jwtTokenProvider.generateTokenPair(user.getUserId());
@@ -65,13 +78,12 @@ public class AuthService implements
     }
 
     @Override
-    public void withdraw(Long userId, String authCode) {
+    public void withdraw(Long userId) {
         User user = userPort.findUserById(userId);
         if(user.getPlatform() == Platform.KAKAO) {
             kakaoService.unlink(user.getPlatformId());
         } else if(user.getPlatform() == Platform.APPLE) {
-            // Apple revoke 스킵 (자체 토큰 발급 이슈)
-            // appleService.revoke(authCode);
+            appleService.revokeByUserId(userId);
         } else {
             throw new AuthException(AuthErrorMessage.PLATFORM_NOT_FOUND);
         }

--- a/src/main/java/com/spoony/spoony_server/application/auth/service/AuthService.java
+++ b/src/main/java/com/spoony/spoony_server/application/auth/service/AuthService.java
@@ -44,6 +44,9 @@ public class AuthService implements
         User user = userPort.create(platformUserDTO, userSignupDTO);
 
         if (userSignupDTO.platform() == Platform.APPLE) {
+            if (userSignupDTO.authCode() == null || userSignupDTO.authCode().isBlank()) {
+                throw new AuthException(AuthErrorMessage.EMPTY_AUTH_CODE);
+            }
             appleService.exchangeAndStoreRefreshToken(userSignupDTO.authCode(), user.getUserId());
         }
 
@@ -63,6 +66,9 @@ public class AuthService implements
 
         if (platformRequestDTO.platform() == Platform.APPLE
                 && appleRefreshTokenPort.findRefreshTokenByUserId(user.getUserId()).isEmpty()) {
+            if (platformRequestDTO.authCode() == null || platformRequestDTO.authCode().isBlank()) {
+                throw new AuthException(AuthErrorMessage.EMPTY_AUTH_CODE);
+            }
             appleService.exchangeAndStoreRefreshToken(platformRequestDTO.authCode(), user.getUserId());
         }
 

--- a/src/main/java/com/spoony/spoony_server/global/auth/encryptor/AppleRefreshTokenEncryptor.java
+++ b/src/main/java/com/spoony/spoony_server/global/auth/encryptor/AppleRefreshTokenEncryptor.java
@@ -1,0 +1,101 @@
+package com.spoony.spoony_server.global.auth.encryptor;
+
+import com.spoony.spoony_server.global.exception.AuthException;
+import com.spoony.spoony_server.global.message.auth.AuthErrorMessage;
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+@Converter
+public class AppleRefreshTokenEncryptor implements AttributeConverter<String, String> {
+
+    private static final String SCHEME_PREFIX = "v1:";
+    private static final String AAD = "apple-refresh";
+    private static final int IV_LEN = 12;
+    private static final int TAG_LEN_BITS = 128;
+
+    private static final SecureRandom RNG = new SecureRandom();
+    private static final Base64.Encoder B64E = Base64.getEncoder();
+    private static final Base64.Decoder B64D = Base64.getDecoder();
+
+    private static volatile SecretKey KEY;
+
+    // Base64 키 문자열로부터 SecretKey 세팅
+    private static void setKeyBase64(String keyB64) {
+        byte[] raw;
+        try {
+            raw = B64D.decode(keyB64);
+        } catch (Exception e) {
+            throw new AuthException(AuthErrorMessage.INVALID_SECRET_KEY);
+        }
+
+        KEY = new SecretKeySpec(raw, "AES");
+    }
+
+    @Override
+    public String convertToDatabaseColumn(String plain) {
+        try {
+            byte[] iv = new byte[IV_LEN];
+            RNG.nextBytes(iv);
+
+            Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            cipher.init(Cipher.ENCRYPT_MODE, KEY, new GCMParameterSpec(TAG_LEN_BITS, iv));
+            cipher.updateAAD(AAD.getBytes(StandardCharsets.UTF_8));
+
+            byte[] ct = cipher.doFinal(plain.getBytes(StandardCharsets.UTF_8));
+            byte[] out = ByteBuffer.allocate(iv.length + ct.length).put(iv).put(ct).array();
+            return SCHEME_PREFIX + B64E.encodeToString(out);
+        } catch (Exception e) {
+            throw new AuthException(AuthErrorMessage.ENCRYPT_FAILED);
+        }
+    }
+
+    @Override
+    public String convertToEntityAttribute(String db) {
+        if (!db.startsWith(SCHEME_PREFIX)) {
+            return db;
+        }
+
+        try {
+            byte[] all = B64D.decode(db.substring(SCHEME_PREFIX.length()));
+            if (all.length < IV_LEN + 16) {
+                throw new AuthException(AuthErrorMessage.INVALID_CIPHERTEXT);
+            }
+            byte[] iv = new byte[IV_LEN];
+            System.arraycopy(all, 0, iv, 0, IV_LEN);
+            byte[] ct = new byte[all.length - IV_LEN];
+            System.arraycopy(all, IV_LEN, ct, 0, ct.length);
+
+            Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            cipher.init(Cipher.DECRYPT_MODE, KEY, new GCMParameterSpec(TAG_LEN_BITS, iv));
+            cipher.updateAAD(AAD.getBytes(StandardCharsets.UTF_8));
+
+            return new String(cipher.doFinal(ct), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new AuthException(AuthErrorMessage.DECRYPT_FAILED);
+        }
+    }
+
+    @Component
+    public static class KeyLoader {
+
+        @Value("${security.token.key-base64}")
+        private String keyBase64;
+
+        @PostConstruct
+        public void init() {
+            AppleRefreshTokenEncryptor.setKeyBase64(keyBase64);
+        }
+    }
+}

--- a/src/main/java/com/spoony/spoony_server/global/message/auth/AuthErrorMessage.java
+++ b/src/main/java/com/spoony/spoony_server/global/message/auth/AuthErrorMessage.java
@@ -20,6 +20,7 @@ public enum AuthErrorMessage implements DefaultErrorMessage {
     CREATE_PUBLIC_KEY_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "Apple Public Key 생성에 실패하였습니다."),
     APPLE_REVOKE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Apple 회원 탈퇴에 실패하였습니다."),
     APPLE_TOKEN_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Apple 토큰 요청에 실패하였습니다."),
+    EMPTY_AUTH_CODE(HttpStatus.BAD_REQUEST, "Auth Code가 비어 있거나 잘못된 요청입니다."),
 
     // JWT (ACCESS)
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),

--- a/src/main/java/com/spoony/spoony_server/global/message/auth/AuthErrorMessage.java
+++ b/src/main/java/com/spoony/spoony_server/global/message/auth/AuthErrorMessage.java
@@ -39,7 +39,13 @@ public enum AuthErrorMessage implements DefaultErrorMessage {
 
     // JWT (ACCESS + REFRESH)
     INVALID_TOKEN_TYPE(HttpStatus.BAD_REQUEST, "올바르지 않은 토큰 타입입니다."),
-    LOGIN_REQUIRED(HttpStatus.LOCKED, "재로그인이 필요합니다.");
+    LOGIN_REQUIRED(HttpStatus.LOCKED, "재로그인이 필요합니다."),
+
+    // Encrypt
+    INVALID_SECRET_KEY(HttpStatus.BAD_REQUEST, "KEY가 비어 있거나 유효하지 않습니다."),
+    ENCRYPT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "암호화에 실패했습니다."),
+    INVALID_CIPHERTEXT(HttpStatus.BAD_REQUEST, "올바르지 않은 토큰 암호문입니다."),
+    DECRYPT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "복호화에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/spoony/spoony_server/global/message/auth/AuthErrorMessage.java
+++ b/src/main/java/com/spoony/spoony_server/global/message/auth/AuthErrorMessage.java
@@ -20,7 +20,7 @@ public enum AuthErrorMessage implements DefaultErrorMessage {
     CREATE_PUBLIC_KEY_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "Apple Public Key 생성에 실패하였습니다."),
     APPLE_REVOKE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Apple 회원 탈퇴에 실패하였습니다."),
     APPLE_TOKEN_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Apple 토큰 요청에 실패하였습니다."),
-    EMPTY_AUTH_CODE(HttpStatus.BAD_REQUEST, "Auth Code가 비어 있거나 잘못된 요청입니다."),
+    EMPTY_AUTH_CODE(HttpStatus.BAD_REQUEST, "Authorization Code가 비어 있거나 잘못된 요청입니다."),
 
     // JWT (ACCESS)
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),

--- a/src/test/java/com/spoony/spoony_server/AppleRefreshTokenUpsertTest.java
+++ b/src/test/java/com/spoony/spoony_server/AppleRefreshTokenUpsertTest.java
@@ -1,0 +1,123 @@
+package com.spoony.spoony_server;
+
+import com.spoony.spoony_server.adapter.auth.out.persistence.AppleRefreshTokenAdapter;
+import com.spoony.spoony_server.adapter.out.persistence.user.db.AppleRefreshTokenEntity;
+import com.spoony.spoony_server.adapter.out.persistence.user.db.AppleRefreshTokenRepository;
+import com.spoony.spoony_server.application.auth.port.out.AppleRefreshTokenPort;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Import({
+        AppleRefreshTokenAdapter.class,
+        com.spoony.spoony_server.global.auth.encryptor.AppleRefreshTokenEncryptor.KeyLoader.class
+})
+@TestPropertySource(properties = {
+        // 32바이트 AES 테스트용 키(Base64)
+        "security.token.key-base64=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+})
+public class AppleRefreshTokenUpsertTest {
+
+    @Autowired
+    AppleRefreshTokenPort port;
+
+    @Autowired
+    AppleRefreshTokenRepository repository;
+
+    @Autowired
+    JdbcTemplate jdbc;
+
+    // 암호화 및 복호화가 JPA 단에서 잘 잘동하는지
+    @Test
+    void upsert_insert_shouldEncryptColumn_andDecryptOnRead() {
+        Long userId = 92001L;
+        String plain = "token-insert-realdb";
+
+        // when
+        port.upsert(userId, plain);
+        repository.flush();
+
+        // then
+        AppleRefreshTokenEntity loaded = repository.findById(userId).orElseThrow();
+        assertThat(loaded.getRefreshToken()).isEqualTo(plain);
+
+        // 실제 DB 컬럼은 암호문이어야 함
+        String raw = jdbc.queryForObject(
+                "select refresh_token from apple_refresh_token where user_id=?",
+                String.class, userId
+        );
+        assertThat(raw).startsWith("v1:");
+        assertThat(raw).doesNotContain(plain);
+
+        // row 1건
+        Integer cnt = jdbc.queryForObject(
+                "select count(*) from apple_refresh_token where user_id=?",
+                Integer.class, userId
+        );
+        assertThat(cnt).isEqualTo(1);
+    }
+
+    // 신규 추가가 잘되는지, 기존에 있는 유저라면 잘 갈아끼워지는지
+    @Test
+    void upsert_update_shouldOverwrite_withoutDuplicateRow_andChangeCiphertext() {
+        Long userId = 92002L;
+
+        // given
+        port.upsert(userId, "old-token");
+        repository.flush();
+        String beforeCipher = jdbc.queryForObject(
+                "select refresh_token from apple_refresh_token where user_id=?",
+                String.class, userId
+        );
+
+        // when
+        port.upsert(userId, "new-token");
+        repository.flush();
+
+        // then
+        AppleRefreshTokenEntity loaded = repository.findById(userId).orElseThrow();
+        assertThat(loaded.getRefreshToken()).isEqualTo("new-token");
+
+        // row 1건
+        Integer cnt = jdbc.queryForObject(
+                "select count(*) from apple_refresh_token where user_id=?",
+                Integer.class, userId
+        );
+        assertThat(cnt).isEqualTo(1);
+
+        // 암호문 변경
+        String afterCipher = jdbc.queryForObject(
+                "select refresh_token from apple_refresh_token where user_id=?",
+                String.class, userId
+        );
+        assertThat(afterCipher).startsWith("v1:");
+        assertThat(afterCipher).isNotEqualTo(beforeCipher);
+    }
+
+    // user_id를 이용한 refresh token 조회
+    @Test
+    void findRefreshTokenByUserId_shouldReturnOptional() {
+        Long userId = 92003L;
+
+        // not present
+        Optional<String> none = port.findRefreshTokenByUserId(userId);
+        assertThat(none).isEmpty();
+
+        // insert
+        port.upsert(userId, "found-me");
+        Optional<String> some = port.findRefreshTokenByUserId(userId);
+        assertThat(some).contains("found-me");
+    }
+}


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?
- closed #210 
- 기존에는`id_token`만을 활용해 로그인/회원가입은 가능했으나, Apple 계정 탈퇴(연동 해제) 기능이 불가능.
  - Apple 계정 탈퇴를 위해서는 `Authrization_Code`을 이용한 구현이 필요.
- 이를 해결하기 위해 `Authorization_Code`를 통해 `Apple refresh_token`를 발급한 뒤 revoke API 호출을 구현.

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
- Apple 회원가입/로그인 수정
  - 회원가입/로그인 시 iOS 환경에서 `Authorization_Code` 수신
  - 회원가입 시: 무조건 `Apple refresh_token` 발급 및 DB 저장
  - 로그인 시: 미보유 시 `Apple refresh_token` 발급 및 DB 저장
- Apple 탈퇴 플로우 추가
  - DB에 저장된 `Apple refresh_token` 조회 후 `/auth/revoke` 호출
  - revoke 성공 시 사용자 및 토큰 데이터 삭제
- `AppleFeignClient`에 revoke 요청 메서드 추가
- `AppleClientSecretGenerator`를 통해 `client_secret`(ES256) JWT를 생성하여 Apple API 인증 처리
- DB 스키마 변경
  - `apple_refresh_token` 테이블 추가 (user_id, refresh_token 저장)

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
- APPLE 회원 전용 `refresh_token` 관리 테이블 생성 (`apple_refresh_token`) 

## 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요
- Apple 로그인/탈퇴 플로우 구현의 안정성 및 보안성 확인
- DB에 `refresh_token` 저장 구조가 확장성과 일관성을 보장하는지 확인

## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?
- iOS에서 `id_token`, `Authorization_Code` 기반 회원가입/로그인 시 토큰 정상 발급 여부
- 실제 iOS 단말에서 아래 플로우 검증 필요
  - 로그인 → 회원가입 → 탈퇴 진행
  - 탈퇴 후 Apple 단말 설정 > 암호 및 보안 > Apple ID 사용 앱 목록에서 정상적으로 서비스가 제거되는지 확인

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 3일 이내에 진행해 주세요.
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)

---
## 📝 Assignee를 위한 CheckList
- [ ] iOS 단말에서 로그인/회원가입/탈퇴 플로우 테스트
- [ ] revoke API 호출 성공 시 DB 데이터 삭제 확인
- [x] `apple_refresh_token` 테이블 생성 및 정상 동작 여부 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 애플 로그인/회원가입 시 Auth Code로 리프레시 토큰을 교환해 안전하게 저장하고 자동 재사용합니다.
  - 로그인 요청에 플랫폼 정보와 Auth Code를 함께 전달할 수 있습니다.
  - 빈/유효하지 않은 Auth Code에 대해 명확한 오류 메시지가 제공됩니다.
- 변경 사항
  - 회원 탈퇴 절차가 단순화되어 더 이상 Auth Code 입력이 필요하지 않습니다.
  - 애플 리프레시 토큰은 저장·조회·철회 기능이 추가되어 자동 관리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->