### PR TITLE
[FIX] 찜카운트 관련 로직 수정 및 테스트

### DIFF
--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/post/db/PostRepository.java
@@ -17,16 +17,15 @@ public interface PostRepository extends JpaRepository<PostEntity, Long> , JpaSpe
     Long countByUser_UserId(@Param("userId") Long userId,
                             @Param("reportedPostIds") List<Long> reportedPostIds);
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select p from PostEntity p where p.postId = :postId")
-    Optional<PostEntity> findByIdForUpdate(@Param("postId") Long postId);
+    @Query(value = "SELECT 1 FROM post WHERE post_id = :postId FOR UPDATE", nativeQuery = true)
+    void lockPostForUpdate(@Param("postId") Long postId);
 
-    @Modifying
-    @Query("update PostEntity p set p.zzimCount = coalesce(p.zzimCount, 0) + 1 where p.postId = :postId")
+    @Modifying(clearAutomatically = true)
+    @Query("update PostEntity p set p.zzimCount = coalesce(p.zzimCount,0) + 1 where p.postId = :postId")
     void incrementZzimCount(@Param("postId") Long postId);
 
-    @Modifying
-    @Query("update PostEntity p set p.zzimCount = case when coalesce(p.zzimCount, 0) > 0 then p.zzimCount - 1 else 0 end where p.postId = :postId")
+    @Modifying(clearAutomatically = true)
+    @Query("update PostEntity p set p.zzimCount = case when coalesce(p.zzimCount,0)>0 then p.zzimCount-1 else 0 end where p.postId = :postId")
     void decrementZzimCount(@Param("postId") Long postId);
 
     //Long countByUser_UserId(Long userId);

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/zzim/ZzimPersistenceAdapter.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/zzim/ZzimPersistenceAdapter.java
@@ -18,14 +18,8 @@ import com.spoony.spoony_server.global.exception.BusinessException;
 import com.spoony.spoony_server.global.message.business.PostErrorMessage;
 import com.spoony.spoony_server.global.message.business.UserErrorMessage;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.CannotAcquireLockException;
-import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.dao.DeadlockLoserDataAccessException;
-import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
@@ -68,15 +62,6 @@ public class ZzimPersistenceAdapter implements ZzimPostPort {
                 .toList();
     }
 
-    @Retryable(
-            retryFor = {
-                    DeadlockLoserDataAccessException.class,
-                    CannotAcquireLockException.class,
-                    PessimisticLockingFailureException.class
-            },
-            maxAttempts = 5,
-            backoff = @Backoff(delay = 5, maxDelay = 50, multiplier = 1.6, random = true)
-    )
     @Transactional(isolation = Isolation.READ_COMMITTED)
     @Override
     public void saveZzimPost(User user, Post post) {
@@ -84,19 +69,15 @@ public class ZzimPersistenceAdapter implements ZzimPostPort {
                 .orElseThrow(() -> new BusinessException(UserErrorMessage.USER_NOT_FOUND));
         UserEntity userEntity_author =  userRepository.findById(post.getUser().getUserId())
                 .orElseThrow(() -> new BusinessException(UserErrorMessage.USER_NOT_FOUND));
-        PostEntity postEntity = postRepository.findByIdForUpdate(post.getPostId())
+        PostEntity postEntity = postRepository.findById(post.getPostId())
                 .orElseThrow(() -> new BusinessException(PostErrorMessage.POST_NOT_FOUND));
 
-        ZzimPostEntity zzimPostEntity = ZzimPostEntity.builder()
-                .user(userEntity)
-                .author(userEntity_author)
-                .post(postEntity)
-                .build();
+        postRepository.lockPostForUpdate(postEntity.getPostId());
 
-        try {
-            zzimPostRepository.saveAndFlush(zzimPostEntity);
-            postRepository.incrementZzimCount(post.getPostId());
-        } catch (DataIntegrityViolationException e) {
+        int inserted = zzimPostRepository.insertIfAbsent(userEntity.getUserId(), postEntity.getPostId(), userEntity_author.getUserId());
+        if (inserted == 1) {
+            postRepository.incrementZzimCount(postEntity.getPostId());
+        } else {
             throw new BusinessException(PostErrorMessage.ALREADY_ZZIM);
         }
     }
@@ -117,24 +98,16 @@ public class ZzimPersistenceAdapter implements ZzimPostPort {
                 .toList();
     }
 
-    @Retryable(
-            retryFor = {
-                    DeadlockLoserDataAccessException.class,
-                    CannotAcquireLockException.class,
-                    PessimisticLockingFailureException.class
-            },
-            maxAttempts = 5,
-            backoff = @Backoff(delay = 5, maxDelay = 50, multiplier = 1.6, random = true)
-    )
     @Transactional(isolation = Isolation.READ_COMMITTED)
     @Override
     public void deleteByUserAndPost(User user, Post post) {
-        PostEntity postEntity = postRepository.findByIdForUpdate(post.getPostId())
+        PostEntity postEntity = postRepository.findById(post.getPostId())
                 .orElseThrow(() -> new BusinessException(PostErrorMessage.POST_NOT_FOUND));
 
-        int deleted = zzimPostRepository.deleteByUser_UserIdAndPost_PostId(user.getUserId(), postEntity.getPostId());
+        postRepository.lockPostForUpdate(postEntity.getPostId());
 
-        if (deleted > 0) {
+        int deleted = zzimPostRepository.deleteOne(user.getUserId(), postEntity.getPostId());
+        if (deleted == 1) {
             postRepository.decrementZzimCount(postEntity.getPostId());
         }
     }

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/zzim/db/ZzimPostRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/zzim/db/ZzimPostRepository.java
@@ -5,6 +5,9 @@ import com.spoony.spoony_server.adapter.out.persistence.user.db.UserEntity;
 import com.spoony.spoony_server.domain.zzim.ZzimPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,17 +15,20 @@ import java.util.List;
 
 @Repository
 public interface ZzimPostRepository extends JpaRepository<ZzimPostEntity, Long>, JpaSpecificationExecutor<ZzimPostEntity> {
-    Long countByPost_PostId(Long postId);
-    Long countByUser_UserId(Long userId);
     boolean existsByUser_UserIdAndPost_PostId(Long userId, Long postId);
-    List<ZzimPostEntity> findByUser_UserId(Long userId);
-    // 북마크 삭제에서 사용
-    int deleteByUser_UserIdAndPost_PostId(Long userId, Long postId);
+
+    @Modifying
+    @Query(value = "INSERT IGNORE INTO zzim_post (user_id, post_id, author_id, created_at) VALUES (:userId, :postId, :authorId, NOW())", nativeQuery = true)
+    int insertIfAbsent(@Param("userId") Long userId,
+                       @Param("postId") Long postId,
+                       @Param("authorId") Long authorId);
+
+    @Modifying
+    @Query(value = "DELETE FROM zzim_post WHERE user_id = :userId AND post_id = :postId", nativeQuery = true)
+    int deleteOne(@Param("userId") Long userId, @Param("postId") Long postId);
 
     //유저 신고에서 사용
     void deleteByUserAndAuthorAndPost(UserEntity user, UserEntity author, PostEntity post);
-
-
 }
 
 

--- a/src/main/java/com/spoony/spoony_server/adapter/out/persistence/zzim/db/ZzimPostRepository.java
+++ b/src/main/java/com/spoony/spoony_server/adapter/out/persistence/zzim/db/ZzimPostRepository.java
@@ -29,6 +29,8 @@ public interface ZzimPostRepository extends JpaRepository<ZzimPostEntity, Long>,
 
     //유저 신고에서 사용
     void deleteByUserAndAuthorAndPost(UserEntity user, UserEntity author, PostEntity post);
+
+    long countByPost_PostId(long pid);
 }
 
 

--- a/src/main/java/com/spoony/spoony_server/domain/zzim/ZzimPost.java
+++ b/src/main/java/com/spoony/spoony_server/domain/zzim/ZzimPost.java
@@ -2,11 +2,18 @@ package com.spoony.spoony_server.domain.zzim;
 
 import com.spoony.spoony_server.domain.post.Post;
 import com.spoony.spoony_server.domain.user.User;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@Table(
+    uniqueConstraints = {
+            @UniqueConstraint(name = "uq_zzim_user_post", columnNames = {"user_id", "post_id"})
+    }
+)
 public class ZzimPost {
     private Long zzimId;
     private User user;

--- a/src/main/java/com/spoony/spoony_server/domain/zzim/ZzimPost.java
+++ b/src/main/java/com/spoony/spoony_server/domain/zzim/ZzimPost.java
@@ -2,18 +2,11 @@ package com.spoony.spoony_server.domain.zzim;
 
 import com.spoony.spoony_server.domain.post.Post;
 import com.spoony.spoony_server.domain.user.User;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-@Table(
-    uniqueConstraints = {
-            @UniqueConstraint(name = "uq_zzim_user_post", columnNames = {"user_id", "post_id"})
-    }
-)
 public class ZzimPost {
     private Long zzimId;
     private User user;

--- a/src/test/java/com/spoony/spoony_server/ZzimCountTest.java
+++ b/src/test/java/com/spoony/spoony_server/ZzimCountTest.java
@@ -24,8 +24,8 @@ public class ZzimCountTest {
     @Autowired private PostRepository postRepository;
     @Autowired private ZzimPostRepository zzimPostRepository;
 
-    private final Long postId = 28L;
-    private final List<Long> userIds = Arrays.asList(33L, 34L, 35L);
+    private final Long postId = 1L;
+    private final List<Long> userIds = Arrays.asList(1L, 2L, 16L);
 
     @Test
     void 서로_다른_세명이_동시에_찜하면_정확히_3증가() throws Exception {

--- a/src/test/java/com/spoony/spoony_server/ZzimCountTest.java
+++ b/src/test/java/com/spoony/spoony_server/ZzimCountTest.java
@@ -5,6 +5,8 @@ import com.spoony.spoony_server.adapter.out.persistence.zzim.db.ZzimPostReposito
 import com.spoony.spoony_server.application.port.command.zzim.ZzimAddCommand;
 import com.spoony.spoony_server.application.port.command.zzim.ZzimDeleteCommand;
 import com.spoony.spoony_server.application.service.zzim.ZzimPostService;
+import com.spoony.spoony_server.global.exception.BusinessException;
+import com.spoony.spoony_server.global.message.business.PostErrorMessage;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,6 +16,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
@@ -94,4 +97,138 @@ public class ZzimCountTest {
         long after = postRepository.findById(postId).orElseThrow().getZzimCount();
         assertThat(after).isEqualTo(before - userIds.size());
     }
+
+    @Test
+    void 한유저가_저장취소_10번_왕복_최종_카운트_0() throws InterruptedException {
+        final Long uid = 1L;
+        final Long pid = 4L;
+
+        assertThat(zzimPostRepository.existsByUser_UserIdAndPost_PostId(uid, pid)).isFalse();
+        assertThat(postRepository.findById(pid).orElseThrow().getZzimCount()).isZero();
+
+        int rounds = 20; // 클릭 횟수 (10쌍)
+        for (int i = 0; i < rounds; i++) {
+            if (i % 2 == 0) {
+                zzimService.addZzimPost(new ZzimAddCommand(uid, pid));
+            } else {
+                zzimService.deleteZzim(new ZzimDeleteCommand(uid, pid));
+            }
+            Thread.sleep(5); // 5ms 간격 (최대한 빠르게 누르는 상황을 테스트하기 위함)
+        }
+
+        // 중간 검증: 최종 상태는 0
+        boolean existsAfterToggle = zzimPostRepository.existsByUser_UserIdAndPost_PostId(uid, pid);
+        long countAfterToggle = postRepository.findById(pid).orElseThrow().getZzimCount();
+
+        assertThat(existsAfterToggle).isFalse();
+        assertThat(countAfterToggle).isZero();
+
+        // 마지막으로 한 번 저장
+        zzimService.addZzimPost(new ZzimAddCommand(uid, pid));
+
+        // 최종 검증: 레코드 존재, 카운트 +1
+        boolean existsFinal = zzimPostRepository.existsByUser_UserIdAndPost_PostId(uid, pid);
+        long countFinal = postRepository.findById(pid).orElseThrow().getZzimCount();
+
+        assertThat(existsFinal).isTrue();
+        assertThat(countFinal).isEqualTo(1);
+    }
+
+    @Test
+    void 한유저가_같은글_따닥저장_최종_카운트_1() throws Exception {
+        final Long uid = 1L;
+        final Long pid = 4L;
+
+        int threads = 2;
+        ExecutorService es = Executors.newFixedThreadPool(threads);
+        CountDownLatch ready = new CountDownLatch(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done  = new CountDownLatch(threads);
+
+        AtomicInteger success = new AtomicInteger();
+        AtomicInteger already = new AtomicInteger();
+        AtomicInteger other   = new AtomicInteger();
+
+        Runnable work = () -> {
+            ready.countDown();
+            try { start.await(); } catch (InterruptedException ignored) {}
+            try {
+                zzimService.addZzimPost(new ZzimAddCommand(uid, pid));
+                success.incrementAndGet();
+            } catch (BusinessException be) {
+                if (be.getErrorMessage() == PostErrorMessage.ALREADY_ZZIM) {
+                    already.incrementAndGet();
+                } else {
+                    other.incrementAndGet();
+                }
+            } catch (Exception e) {
+                other.incrementAndGet();
+            } finally {
+                done.countDown();
+            }
+        };
+
+        for (int i = 0; i < threads; i++) es.submit(work);
+
+        ready.await();
+        start.countDown();
+        done.await();
+        es.shutdown();
+
+        // 정확히 한 번만 성공, 한 번은 중복 예외, 그 외 예외 없음
+        assertThat(success.get()).isEqualTo(1);
+        assertThat(already.get()).isEqualTo(1);
+        assertThat(other.get()).isEqualTo(0);
+
+        // zzim_post 최종 1건 존재
+        assertThat(zzimPostRepository.existsByUser_UserIdAndPost_PostId(uid, pid)).isTrue();
+
+        // post.zzimCount 최종 1
+        long count = postRepository.findById(pid).orElseThrow().getZzimCount();
+        assertThat(count).isEqualTo(1L);
+    }
+
+    @Test
+    void 같은유저_같은포스트_따닥삭제시_최종값_0() throws Exception {
+        final long uid = 1L;
+        final long pid = 4L;
+
+        int threads = 2;
+        ExecutorService es = Executors.newFixedThreadPool(threads);
+        CountDownLatch ready = new CountDownLatch(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done  = new CountDownLatch(threads);
+
+        AtomicInteger otherErrors = new AtomicInteger();
+
+        Runnable work = () -> {
+            ready.countDown();
+            try { start.await(); } catch (InterruptedException ignored) {}
+            try {
+                zzimService.deleteZzim(new ZzimDeleteCommand(uid, pid));
+            } catch (Exception e) {
+                otherErrors.incrementAndGet();
+            } finally {
+                done.countDown();
+            }
+        };
+
+        for (int i = 0; i < threads; i++) es.submit(work);
+
+        ready.await();
+        start.countDown();
+        done.await();
+        es.shutdown();
+
+        // 예기치 않은 예외 없어야 함
+        assertThat(otherErrors.get()).isEqualTo(0);
+
+        // 최종 상태 검증: 레코드 없음 + 카운트 0
+        boolean existsAfter = zzimPostRepository.existsByUser_UserIdAndPost_PostId(uid, pid);
+        long countAfter = postRepository.findById(pid).orElseThrow().getZzimCount();
+
+        assertThat(existsAfter).isFalse();
+        assertThat(countAfter).isZero();
+    }
+
 }


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?
- closed #231 
- 기존 동시성 이슈를 해결하면서 수정된 로직을 최적화하기 위해 다시 한 번 손을 봤습니다.
- 다양한 상황에 대한 테스트도 진행했습니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
- 기존 방법
  - 기존 로직 `saveAndFlush`방식은 Post를 `FOR UPDATE`로 잡은 상태에서 자식`INSERT`를 즉시 플러시하면서 데드락이 발생합니다. 
  -  따라서 `@Retryable`을 사용하여 해결하였습니다.
- 수정 방법
  - `saveAndFlush`를 제거합니다.
  - 단일 `INSERT`/`DELETE` + 영향행수 기반으로 찜카운트를 증감합니다.

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
> 없음

## 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요
- 추가적으로 테스트해야 할 상황이 필요하다면 말씀해주세요~

## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?
- 테스트 진행한 부분
  - [x] 여러 명이 동시에 찜을 눌렀을 때
  - [x] 여러 명이 동시에 찜 취소를 눌렀을 때
  - [x] 찜/찜취소 따닥 이슈
  - [x] 두 명의 유저가 찜/찜취소를 랜덤으로 50번씩 아주 빠르게 요청했을 때
    - 네트워크 지연이나 순서가 뒤바껴 들어오는 상황을 가정하여 랜덤으로 요청합니다.
  - [x] 한 명의 유저가 같은 글에 대해 여러 스레드로 광클(찜, 찜취소 랜덤)했을 때 
    - 위와 동일하게 랜덤으로 요청합니다.
- 기존 로직으로는 통과하지 못했던 테스트가 수정된 로직에서는 모두 통과하였습니다.   


### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 3일 이내에 진행해 주세요.
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 동시 다중 사용자 환경에서 찜/취소 시 발생하던 간헐적 카운트 불일치와 중복 찜 문제를 수정했습니다. 이제 화면과 서버의 찜 수가 일관되게 표시됩니다.
- Refactor
  - 동시성 제어를 개선해 중복 동작을 예방하고 처리 안정성을 높였습니다. 트래픽 급증 상황에서도 찜 상태와 카운트 반영이 더욱 신뢰성 있게 동작합니다.
- Tests
  - 대량 동시 요청과 토글 시나리오에 대한 테스트를 추가해 실제 사용 환경에서의 일관성과 무결성을 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->